### PR TITLE
Add stronger lexer edge case tests

### DIFF
--- a/skeplib/tests/lexer.rs
+++ b/skeplib/tests/lexer.rs
@@ -150,7 +150,10 @@ fn ignores_block_comment_with_punctuation_and_keywords_inside() {
     let (tokens, diags) = lex("/* if else == [] {} // not real */ return;");
     assert!(diags.is_empty(), "diagnostics: {:?}", diags.as_slice());
     let got: Vec<TokenKind> = tokens.into_iter().map(|t| t.kind).collect();
-    assert_eq!(got, vec![TokenKind::KwReturn, TokenKind::Semi, TokenKind::Eof]);
+    assert_eq!(
+        got,
+        vec![TokenKind::KwReturn, TokenKind::Semi, TokenKind::Eof]
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
Adds stronger lexer coverage for edge cases around token boundaries, comments, error recovery, and span tracking.

## What changed
- added tests for reserved keywords not previously covered: `from`, `as`, `export`, `struct`, `impl`
- added checks to ensure lowercase type names like `int` and `float` stay `Ident` tokens
- added boundary tests for `123abc`, `3.14foo`, and `1..2`
- added comment handling coverage for EOF comments and noisy block comments
- added recovery tests for lone `&` and unterminated strings
- added line/column span checks for invalid characters and tokens after multiline block comments
- added a check that escaped string literals preserve the raw token lexeme

## Why
Lexer bugs tend to surface later as parser or semantic failures, which makes them harder to diagnose. These tests make the lexer contract tighter and help catch subtle regressions earlier.

## Verification
```bash
cargo test -p skeplib --test lexer
