### PR TITLE
fix(codegen): lower bool compares using i1

### DIFF
--- a/skeplib/src/codegen/llvm/context.rs
+++ b/skeplib/src/codegen/llvm/context.rs
@@ -286,13 +286,14 @@ impl<'a> LlvmEmitter<'a> {
                 right,
             } => {
                 let dest = names.temp(*dst)?;
+                let compare_ty = infer_compare_operand_type(self.program, func, left, right);
                 let left = operand_load(
                     names,
                     left,
                     func,
                     lines,
                     counter,
-                    &crate::ir::IrType::Int,
+                    &compare_ty,
                     &self.string_literals,
                 )?;
                 let right = operand_load(
@@ -301,7 +302,7 @@ impl<'a> LlvmEmitter<'a> {
                     func,
                     lines,
                     counter,
-                    &crate::ir::IrType::Int,
+                    &compare_ty,
                     &self.string_literals,
                 )?;
                 let pred = match op {
@@ -312,7 +313,10 @@ impl<'a> LlvmEmitter<'a> {
                     CmpOp::Gt => "sgt",
                     CmpOp::Ge => "sge",
                 };
-                lines.push(format!("  {dest} = icmp {pred} i64 {left}, {right}"));
+                lines.push(format!(
+                    "  {dest} = icmp {pred} {} {left}, {right}",
+                    llvm_ty(&compare_ty)?
+                ));
             }
             Instr::LoadGlobal { dst, ty, global } => {
                 let dest = names.temp(*dst)?;
@@ -848,4 +852,44 @@ fn encode_c_string(value: &str) -> String {
     }
     out.push_str("\\00");
     out
+}
+
+fn infer_compare_operand_type(
+    program: &IrProgram,
+    func: &IrFunction,
+    left: &Operand,
+    right: &Operand,
+) -> crate::ir::IrType {
+    match infer_operand_type(program, func, left)
+        .or_else(|| infer_operand_type(program, func, right))
+    {
+        Some(crate::ir::IrType::Bool) => crate::ir::IrType::Bool,
+        _ => crate::ir::IrType::Int,
+    }
+}
+
+fn infer_operand_type(
+    program: &IrProgram,
+    func: &IrFunction,
+    operand: &Operand,
+) -> Option<crate::ir::IrType> {
+    match operand {
+        Operand::Const(ConstValue::Bool(_)) => Some(crate::ir::IrType::Bool),
+        Operand::Temp(id) => func
+            .temps
+            .iter()
+            .find(|temp| temp.id == *id)
+            .map(|temp| temp.ty.clone()),
+        Operand::Local(id) => func
+            .locals
+            .iter()
+            .find(|local| local.id == *id)
+            .map(|local| local.ty.clone()),
+        Operand::Global(id) => program
+            .globals
+            .iter()
+            .find(|global| global.id == *id)
+            .map(|global| global.ty.clone()),
+        _ => None,
+    }
 }

--- a/skeplib/tests/codegen.rs
+++ b/skeplib/tests/codegen.rs
@@ -556,6 +556,95 @@ fn main() -> Int {
 }
 
 #[test]
+fn llvm_codegen_emits_bool_compare_using_i1() {
+    let source = r#"
+fn main() -> Int {
+  let a = true;
+  let b = false;
+  if (a != b) {
+    return 1;
+  }
+  return 0;
+}
+"#;
+
+    let program = ir::lowering::compile_source(source).expect("IR lowering should succeed");
+    let llvm_ir =
+        codegen::compile_program_to_llvm_ir(&program).expect("LLVM lowering should succeed");
+
+    assert!(llvm_ir.contains("alloca i1"));
+    assert!(llvm_ir.contains("load i1"));
+    assert!(llvm_ir.contains("icmp ne i1"));
+    assert!(!llvm_ir.contains("icmp ne i64"));
+}
+
+#[test]
+fn llvm_codegen_emits_bool_equality_using_i1() {
+    let source = r#"
+fn main() -> Int {
+  let a = true;
+  let b = true;
+  if (a == b) {
+    return 1;
+  }
+  return 0;
+}
+"#;
+
+    let program = ir::lowering::compile_source(source).expect("IR lowering should succeed");
+    let llvm_ir =
+        codegen::compile_program_to_llvm_ir(&program).expect("LLVM lowering should succeed");
+
+    assert!(llvm_ir.contains("load i1"));
+    assert!(llvm_ir.contains("icmp eq i1"));
+    assert!(!llvm_ir.contains("icmp eq i64"));
+}
+
+#[test]
+fn llvm_codegen_emits_global_bool_compare_using_i1() {
+    let source = r#"
+let enabled: Bool = true;
+
+fn main() -> Int {
+  if (enabled == true) {
+    return 1;
+  }
+  return 0;
+}
+"#;
+
+    let program = ir::lowering::compile_source(source).expect("IR lowering should succeed");
+    let llvm_ir =
+        codegen::compile_program_to_llvm_ir(&program).expect("LLVM lowering should succeed");
+
+    assert!(llvm_ir.contains("@g0 = global i1 0"));
+    assert!(llvm_ir.contains("store i1 1, ptr @g0"));
+    assert!(llvm_ir.contains("load i1, ptr @g0"));
+    assert!(llvm_ir.contains("icmp eq i1"));
+}
+
+#[test]
+fn llvm_codegen_keeps_int_compare_using_i64() {
+    let source = r#"
+fn main() -> Int {
+  let a = 1;
+  let b = 2;
+  if (a < b) {
+    return 1;
+  }
+  return 0;
+}
+"#;
+
+    let program = ir::lowering::compile_source(source).expect("IR lowering should succeed");
+    let llvm_ir =
+        codegen::compile_program_to_llvm_ir(&program).expect("LLVM lowering should succeed");
+
+    assert!(llvm_ir.contains("load i64"));
+    assert!(llvm_ir.contains("icmp slt i64"));
+}
+
+#[test]
 fn llvm_codegen_emits_runtime_abi_for_struct_layout_and_builtin_dispatch() {
     let source = r#"
 import fs;


### PR DESCRIPTION
## Summary
Fixes LLVM compare lowering for `Bool` values in `skeplib` codegen.

`Bool` comparisons were being lowered as `i64` even though the values were allocated and stored as `i1`, which produced incorrect LLVM IR. This change makes the compare path type-aware for boolean operands and adds regression coverage around it.

## Area
- codegen
- tests

## Why
This change fixes the bug reported in #8.

Boolean values are already supported across the frontend and runtime, so compare lowering should preserve `Bool` as `i1` in the LLVM backend as well.

## What Changed
- updated `skeplib/src/codegen/llvm/context.rs` so `Instr::Compare` uses the actual operand type for `Bool` comparisons instead of always lowering compares as `i64`
- added regression tests in `skeplib/tests/codegen.rs` for local `Bool` inequality, local `Bool` equality, global `Bool` comparison, and `Int` compare sanity coverage

## Validation
- [x] `cargo fmt --all`
- [x] focused tests for touched area
- [x] `cargo test --workspace` when relevant

Commands run:
```bash
cargo fmt --all
cargo test -p skeplib --test codegen llvm_codegen_emits_bool_compare_using_i1
cargo test -p skeplib --test codegen llvm_codegen_emits_bool_equality_using_i1
cargo test -p skeplib --test codegen llvm_codegen_emits_global_bool_compare_using_i1
cargo test -p skeplib --test codegen llvm_codegen_keeps_int_compare_using_i64
cargo run -p skepac -- build-llvm-ir bool_compare.sk bool_compare.ll
cargo test --workspace --no-fail-fast
