### PR TITLE
fix(codegen): find libskepart beside skepac

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,6 +126,8 @@ jobs:
           PKG="skepa-${OS_LOWER}-x64"
           mkdir -p "$PKG"
           cp target/release/skepac "$PKG/"
+          # build-native links against libskepart; ship it beside skepac for exe-relative discovery
+          cp target/release/libskepart.a "$PKG/"
           cp README.md "$PKG/"
           cp DOCS.md "$PKG/"
           tar -czf "$ARCHIVE_DIR/$PKG.tar.gz" "$PKG"
@@ -138,6 +140,24 @@ jobs:
           $pkg = "skepa-windows-x64"
           New-Item -ItemType Directory -Force $pkg | Out-Null
           Copy-Item target\release\skepac.exe "$pkg\"
+          # build-native links against skepart; ship link + sidecar artifacts beside skepac
+          $runtimeArtifacts = @(
+            "target\release\skepart.dll",
+            "target\release\skepart.dll.lib",
+            "target\release\libskepart.dll.a",
+            "target\release\libskepart.a",
+            "target\release\skepart.lib"
+          )
+          $copied = $false
+          foreach ($path in $runtimeArtifacts) {
+            if (Test-Path $path) {
+              Copy-Item $path "$pkg\"
+              $copied = $true
+            }
+          }
+          if (-not $copied) {
+            throw "No skepart runtime artifacts found under target\release for packaging"
+          }
           Copy-Item README.md "$pkg\"
           Copy-Item DOCS.md "$pkg\"
           Compress-Archive -Path $pkg -DestinationPath "dist\$pkg.zip" -Force

--- a/README.md
+++ b/README.md
@@ -14,13 +14,17 @@ Download from GitHub Releases:
 - Linux: `skepa-linux-x64.tar.gz`
 - macOS: `skepa-macos-x64.tar.gz`
 
-Extract and add binaries to `PATH`.
+Extract the archive and keep `skepac` together with the shipped runtime library (`libskepart.a` on Unix, plus `skepart.dll` / import libs on Windows). Add that directory to `PATH`.
+
+`build-native` finds the runtime beside the `skepac` executable. To point at a different location, set `SKEPA_RUNTIME_DIR` to a directory that contains the runtime library.
 
 ### 2) Install from GitHub with Cargo
 
 ```bash
 cargo install --git https://github.com/AayushMainali-Github/skepa-lang skepac
 ```
+
+`cargo install` only installs the `skepac` binary. For `build-native`, also place `libskepart.a` (and on Windows the `skepart` DLL / import libs) beside `skepac`, or set `SKEPA_RUNTIME_DIR`. Prefer the prebuilt archives or the local install scripts below when you need native builds.
 
 ### 3) Build/install locally
 
@@ -34,11 +38,14 @@ Linux/macOS (bash):
 ./scripts/install.sh
 ```
 
+These scripts install `skepac` and copy the native runtime library next to it.
+
 Manual:
 ```bash
 cargo install --path skepac
+cargo build --release -p skepart
+# then copy target/release/libskepart.a (and Windows DLL artifacts) beside ~/.cargo/bin/skepac
 ```
-
 ## Run
 
 ```bash
@@ -52,6 +59,8 @@ skepac build-llvm-ir app.sk app.ll
 `build-obj` and `build-native` keep local cache metadata, compiled object artifacts, and reusable linked native outputs under `.skepac-cache/`, so unchanged builds can skip recompilation, relink from a cached object, or restore a missing executable from the cached linked artifact.
 
 On Windows GNU builds, `build-native` emits the executable plus `skepart.dll` beside it. Keep both files together when you move or run the built artifact.
+
+If `build-native` reports that the native runtime library is missing, ensure `libskepart` is next to `skepac` or set `SKEPA_RUNTIME_DIR`.
 
 Set `SKEPAC_TIMINGS=1` to print per-phase timing lines for `build-obj` and `build-native` when you want to inspect cache hits, codegen cost, and link cost locally.
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -10,6 +10,8 @@ if (-not (Get-Command cargo -ErrorAction SilentlyContinue)) {
 }
 
 $root = Split-Path -Parent $PSScriptRoot
+$cargoHome = if ($env:CARGO_HOME) { $env:CARGO_HOME } else { Join-Path $env:USERPROFILE ".cargo" }
+$binDir = Join-Path $cargoHome "bin"
 
 $cargoArgs = @("install")
 if ($Force) {
@@ -19,4 +21,28 @@ if ($Force) {
 Write-Host "Installing skepac..."
 & cargo @cargoArgs --path (Join-Path $root "skepac")
 
-Write-Host "Done. Ensure `$env:USERPROFILE\.cargo\bin` is on PATH."
+Write-Host "Building native runtime library..."
+& cargo build --release -p skepart --manifest-path (Join-Path $root "Cargo.toml")
+
+New-Item -ItemType Directory -Force $binDir | Out-Null
+$runtimeArtifacts = @(
+  "skepart.dll",
+  "skepart.dll.lib",
+  "libskepart.dll.a",
+  "libskepart.a",
+  "skepart.lib"
+)
+$copied = $false
+foreach ($name in $runtimeArtifacts) {
+  $src = Join-Path $root "target\release\$name"
+  if (Test-Path $src) {
+    Copy-Item $src (Join-Path $binDir $name) -Force
+    $copied = $true
+  }
+}
+if (-not $copied) {
+  throw "No skepart runtime artifacts found under target\release after release build"
+}
+
+Write-Host "Done. Ensure $binDir is on PATH."
+Write-Host "build-native will find skepart beside skepac (or via SKEPA_RUNTIME_DIR)."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -7,8 +7,21 @@ if ! command -v cargo >/dev/null 2>&1; then
 fi
 
 ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+BIN_DIR="${CARGO_HOME:-$HOME/.cargo}/bin"
 
 echo "Installing skepac..."
 cargo install --path "$ROOT_DIR/skepac"
 
-echo "Done. Ensure ~/.cargo/bin is on PATH."
+echo "Building native runtime library..."
+cargo build --release -p skepart --manifest-path "$ROOT_DIR/Cargo.toml"
+
+if [ ! -f "$ROOT_DIR/target/release/libskepart.a" ]; then
+  echo "expected $ROOT_DIR/target/release/libskepart.a after release build" >&2
+  exit 1
+fi
+
+mkdir -p "$BIN_DIR"
+cp "$ROOT_DIR/target/release/libskepart.a" "$BIN_DIR/"
+
+echo "Done. Ensure $BIN_DIR is on PATH."
+echo "build-native will find libskepart.a beside skepac (or via SKEPA_RUNTIME_DIR)."

--- a/skepac/tests/check_cli.rs
+++ b/skepac/tests/check_cli.rs
@@ -8,7 +8,7 @@ mod common;
 
 use common::{
     CliFailureClass, assert_cli_failure_class, assert_diag_code_and_message, example_entry,
-    exe_ext, make_temp_dir, obj_ext, skepac_bin, write_temp_file,
+    exe_ext, make_temp_dir, obj_ext, repo_root, skepac_bin, write_temp_file,
 };
 
 #[cfg(target_os = "windows")]
@@ -2205,6 +2205,93 @@ fn main() -> Int {
         .output()
         .expect("native executable should run");
     assert_eq!(run.status.code(), Some(7));
+}
+
+fn copy_workspace_runtime_artifacts(dest_dir: &std::path::Path) {
+    let release_dir = repo_root().join("target").join("release");
+    let debug_dir = repo_root().join("target").join("debug");
+    let names = [
+        "libskepart.a",
+        "skepart.dll",
+        "skepart.dll.lib",
+        "libskepart.dll.a",
+        "skepart.lib",
+    ];
+    let mut copied = false;
+    for profile_dir in [&release_dir, &debug_dir] {
+        for name in names {
+            let src = profile_dir.join(name);
+            if src.exists() {
+                fs::copy(&src, dest_dir.join(name)).expect("copy runtime artifact");
+                copied = true;
+            }
+        }
+        if copied {
+            return;
+        }
+        let deps = profile_dir.join("deps");
+        if !deps.exists() {
+            continue;
+        }
+        for entry in fs::read_dir(&deps).expect("read deps") {
+            let entry = entry.expect("deps entry");
+            let path = entry.path();
+            let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+                continue;
+            };
+            let is_runtime = name == "libskepart.a"
+                || name.starts_with("libskepart-") && name.ends_with(".a")
+                || name == "skepart.dll"
+                || name.starts_with("skepart") && name.ends_with(".dll")
+                || name == "libskepart.dll.a"
+                || name.ends_with(".dll.lib")
+                || name == "skepart.lib";
+            if is_runtime {
+                fs::copy(&path, dest_dir.join(name)).expect("copy deps runtime artifact");
+                copied = true;
+            }
+        }
+        if copied {
+            return;
+        }
+    }
+    panic!("workspace skepart runtime artifacts not found under target/{{release,debug}}");
+}
+
+#[test]
+fn build_native_uses_skepa_runtime_dir_override() {
+    let tmp = make_temp_dir("skepac_build_native_runtime_dir");
+    let runtime_dir = tmp.join("runtime");
+    fs::create_dir_all(&runtime_dir).expect("runtime dir");
+    copy_workspace_runtime_artifacts(&runtime_dir);
+
+    let source = tmp.join("main.sk");
+    let out = tmp.join(format!("main.{}", exe_ext()));
+    fs::write(
+        &source,
+        r#"
+fn main() -> Int {
+  return 9;
+}
+"#,
+    )
+    .expect("write source");
+
+    let output = Command::new(skepac_bin())
+        .env("SKEPA_RUNTIME_DIR", &runtime_dir)
+        .arg("build-native")
+        .arg(&source)
+        .arg(&out)
+        .output()
+        .expect("run skepac build-native with SKEPA_RUNTIME_DIR");
+
+    assert!(output.status.success(), "{:?}", output);
+    assert!(out.exists());
+
+    let run = Command::new(&out)
+        .output()
+        .expect("native executable should run");
+    assert_eq!(run.status.code(), Some(9));
 }
 
 #[test]

--- a/skeplib/src/codegen/mod.rs
+++ b/skeplib/src/codegen/mod.rs
@@ -528,9 +528,31 @@ pub fn sync_runtime_sidecars_for_output(path: &Path) -> Result<(), CodegenError>
 }
 
 fn runtime_link_artifacts() -> Result<RuntimeLinkArtifacts, CodegenError> {
+    runtime_link_artifacts_from_search_dirs(&runtime_search_dirs())
+}
+
+fn runtime_search_dirs() -> Vec<PathBuf> {
+    let mut dirs = Vec::new();
+    if let Ok(dir) = std::env::var("SKEPA_RUNTIME_DIR") {
+        let trimmed = dir.trim();
+        if !trimmed.is_empty() {
+            dirs.push(PathBuf::from(trimmed));
+        }
+    }
+    if let Ok(exe) = std::env::current_exe()
+        && let Some(parent) = exe.parent()
+    {
+        push_unique_runtime_search_dir(&mut dirs, parent.to_path_buf());
+    }
+    if let Some(workspace_target) = workspace_target_dir() {
+        push_unique_runtime_search_dir(&mut dirs, workspace_target);
+    }
+    dirs
+}
+
+fn workspace_target_dir() -> Option<PathBuf> {
     let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .ok_or_else(|| CodegenError::Tool("failed to locate workspace root".into()))?
+        .parent()?
         .to_path_buf();
     let profile = std::env::var("PROFILE")
         .ok()
@@ -556,12 +578,32 @@ fn runtime_link_artifacts() -> Result<RuntimeLinkArtifacts, CodegenError> {
                 "release".to_string()
             }
         });
-    runtime_link_artifacts_in_target_dir(&workspace_root.join("target").join(profile))
+    Some(workspace_root.join("target").join(profile))
 }
 
-fn runtime_link_artifacts_in_target_dir(
-    target_dir: &Path,
+fn push_unique_runtime_search_dir(dirs: &mut Vec<PathBuf>, candidate: PathBuf) {
+    if dirs.iter().any(|existing| existing == &candidate) {
+        return;
+    }
+    dirs.push(candidate);
+}
+
+fn runtime_link_artifacts_from_search_dirs(
+    search_dirs: &[PathBuf],
 ) -> Result<RuntimeLinkArtifacts, CodegenError> {
+    let mut searched = Vec::new();
+    for dir in search_dirs {
+        searched.push(dir.clone());
+        if let Some(artifacts) = find_runtime_link_artifacts_in_dir(dir)? {
+            return Ok(artifacts);
+        }
+    }
+    missing_runtime_error_for_dirs(&searched)
+}
+
+fn find_runtime_link_artifacts_in_dir(
+    target_dir: &Path,
+) -> Result<Option<RuntimeLinkArtifacts>, CodegenError> {
     let candidate_dirs = [target_dir.join("deps"), target_dir.to_path_buf()];
     let mut static_candidates = Vec::new();
     let mut shared_import_candidates = Vec::new();
@@ -612,21 +654,21 @@ fn runtime_link_artifacts_in_target_dir(
             shared_import_candidates.into_iter().next(),
             shared_sidecar_candidates.into_iter().next(),
         ) {
-            return Ok(RuntimeLinkArtifacts {
+            return Ok(Some(RuntimeLinkArtifacts {
                 link_lib,
                 sidecar_lib: Some(sidecar_lib),
-            });
+            }));
         }
     }
 
     sort_runtime_candidates(&mut static_candidates);
     if let Some(path) = static_candidates.into_iter().next() {
-        Ok(RuntimeLinkArtifacts {
+        Ok(Some(RuntimeLinkArtifacts {
             link_lib: path,
             sidecar_lib: None,
-        })
+        }))
     } else {
-        missing_runtime_error(target_dir)
+        Ok(None)
     }
 }
 
@@ -659,11 +701,17 @@ fn sort_runtime_candidates(candidates: &mut [PathBuf]) {
     });
 }
 
-fn missing_runtime_error(target_dir: &Path) -> Result<RuntimeLinkArtifacts, CodegenError> {
-    let deps_dir = target_dir.join("deps");
+fn missing_runtime_error_for_dirs(dirs: &[PathBuf]) -> Result<RuntimeLinkArtifacts, CodegenError> {
+    let searched = if dirs.is_empty() {
+        "(no search directories)".to_string()
+    } else {
+        dirs.iter()
+            .map(|dir| dir.join("deps").display().to_string())
+            .collect::<Vec<_>>()
+            .join(", ")
+    };
     Err(CodegenError::Tool(format!(
-        "native runtime library missing under {}",
-        deps_dir.display()
+        "native runtime library missing under {searched}; place libskepart beside skepac or set SKEPA_RUNTIME_DIR"
     )))
 }
 
@@ -726,7 +774,7 @@ mod tests {
         compile_program_to_bitcode_file_with_tool, compile_program_to_llvm_ir,
         compile_program_to_object_file_with_tools, format_timing_line, link_args_for_executable,
         link_command_for_executable, link_object_file_to_executable_with_tool, run_tool,
-        runtime_link_artifacts_in_target_dir, sync_runtime_sidecars,
+        runtime_link_artifacts_from_search_dirs, sync_runtime_sidecars,
     };
     use crate::codegen::llvm::LlvmEmitSection;
     use crate::ir;
@@ -834,13 +882,14 @@ fn main() -> Int {
                 .as_nanos()
         ));
         fs::create_dir_all(&target_dir).expect("temp target dir");
-        let err = runtime_link_artifacts_in_target_dir(&target_dir)
+        let err = runtime_link_artifacts_from_search_dirs(std::slice::from_ref(&target_dir))
             .expect_err("runtime should be missing");
         let _ = fs::remove_dir_all(&target_dir);
         match err {
             CodegenError::Tool(msg) => {
                 assert!(msg.contains("native runtime library missing under"));
                 assert!(msg.contains("deps"));
+                assert!(msg.contains("SKEPA_RUNTIME_DIR"));
             }
             other => panic!("unexpected error kind: {other:?}"),
         }
@@ -862,7 +911,7 @@ fn main() -> Int {
         fs::write(&older, []).expect("older archive");
         std::thread::sleep(std::time::Duration::from_millis(10));
         fs::write(&newer, []).expect("newer archive");
-        let selected = runtime_link_artifacts_in_target_dir(&target_dir)
+        let selected = runtime_link_artifacts_from_search_dirs(std::slice::from_ref(&target_dir))
             .expect("runtime archive should exist");
         let _ = fs::remove_dir_all(&target_dir);
         assert_eq!(
@@ -884,13 +933,74 @@ fn main() -> Int {
         fs::create_dir_all(&deps_dir).expect("temp deps dir");
         let archive = deps_dir.join("libskepart.a");
         fs::write(&archive, []).expect("unhashed archive");
-        let selected = runtime_link_artifacts_in_target_dir(&target_dir)
+        let selected = runtime_link_artifacts_from_search_dirs(std::slice::from_ref(&target_dir))
             .expect("unhashed runtime archive should be discovered");
         let _ = fs::remove_dir_all(&target_dir);
         assert_eq!(
             selected.link_lib.file_name().and_then(|name| name.to_str()),
             Some("libskepart.a")
         );
+    }
+
+    #[test]
+    fn runtime_library_discovery_accepts_archive_beside_executable_dir() {
+        let runtime_dir = std::env::temp_dir().join(format!(
+            "skepa_codegen_runtime_exe_relative_{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ));
+        fs::create_dir_all(&runtime_dir).expect("temp runtime dir");
+        let archive = runtime_dir.join("libskepart.a");
+        fs::write(&archive, []).expect("exe-relative archive");
+        let selected = runtime_link_artifacts_from_search_dirs(std::slice::from_ref(&runtime_dir))
+            .expect("exe-relative runtime archive should be discovered");
+        let _ = fs::remove_dir_all(&runtime_dir);
+        assert_eq!(selected.link_lib, archive);
+    }
+
+    #[test]
+    fn runtime_library_search_prefers_earlier_directory() {
+        let root = std::env::temp_dir().join(format!(
+            "skepa_codegen_runtime_search_order_{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ));
+        let first = root.join("first");
+        let second = root.join("second");
+        fs::create_dir_all(&first).expect("first dir");
+        fs::create_dir_all(&second).expect("second dir");
+        let first_archive = first.join("libskepart.a");
+        let second_archive = second.join("libskepart.a");
+        fs::write(&first_archive, b"first").expect("first archive");
+        fs::write(&second_archive, b"second").expect("second archive");
+        let selected = runtime_link_artifacts_from_search_dirs(&[first.clone(), second.clone()])
+            .expect("runtime archive should be discovered");
+        let _ = fs::remove_dir_all(&root);
+        assert_eq!(selected.link_lib, first_archive);
+    }
+
+    #[test]
+    fn runtime_library_search_falls_through_missing_directories() {
+        let root = std::env::temp_dir().join(format!(
+            "skepa_codegen_runtime_search_fallback_{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ));
+        let missing = root.join("missing");
+        let present = root.join("present");
+        fs::create_dir_all(&present).expect("present dir");
+        let archive = present.join("libskepart.a");
+        fs::write(&archive, []).expect("fallback archive");
+        let selected = runtime_link_artifacts_from_search_dirs(&[missing, present.clone()])
+            .expect("fallback runtime archive should be discovered");
+        let _ = fs::remove_dir_all(&root);
+        assert_eq!(selected.link_lib, archive);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Fixes #14: prebuilt and cargo-installed `skepac` can find `libskepart` for `build-native` by searching beside the executable (and `SKEPA_RUNTIME_DIR`), and release/install packaging now ships the runtime library with the CLI.

## Area
- codegen
- cli
- ci
- docs
- tests

## Why
`runtime_link_artifacts()` only looked under the compile-time workspace `target/<profile>`, and release archives / install scripts only shipped `skepac`. Documented install paths therefore failed native builds outside the original checkout.

## What Changed
- Search runtime libs in order: `SKEPA_RUNTIME_DIR`, directory beside `skepac`, then workspace `target/{profile}`
- Package `libskepart.a` (Unix) and Windows skepart DLL / import libs in `.github/workflows/release.yml`
- Update `scripts/install.sh` / `install.ps1` to copy runtime artifacts next to the installed binary
- Document prebuilt layout and `SKEPA_RUNTIME_DIR` in `README.md`
- Add discovery unit tests and a CLI test for `SKEPA_RUNTIME_DIR`

## Validation
- [x] `cargo fmt --all`
- [x] focused tests for touched area
- [x] `cargo test --workspace` when relevant

Commands run:
```bash
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test --workspace
# simulated prebuilt layout (skepac + libskepart.a, workspace target hidden):
# skepac build-native examples/hello/main.sk hello
```

## Notes for Review
Closes #14. Custom `CARGO_TARGET_DIR` is still not a first-class search root; this PR focuses on exe-relative / env / default workspace `target` discovery plus packaging.