### PR TITLE
fix(runtime): reject CR/LF in fetch method and contentType

### DIFF
--- a/skepart/src/host.rs
+++ b/skepart/src/host.rs
@@ -1251,6 +1251,9 @@ impl RtHost for NoopHost {
             None => String::new(),
         };
 
+        reject_http_control_chars("method", &method)?;
+        reject_http_control_chars("contentType", &content_type)?;
+
         let method = method.to_uppercase();
         let response = self.http_request_with_content_type(url, &method, &body, &content_type)?;
         let map = RtMap::new();

--- a/skepart/src/host.rs
+++ b/skepart/src/host.rs
@@ -1251,8 +1251,8 @@ impl RtHost for NoopHost {
             None => String::new(),
         };
 
-        reject_http_control_chars("method", &method)?;
-        reject_http_control_chars("contentType", &content_type)?;
+        reject_http_control_chars("net.fetch", "method", &method)?;
+        reject_http_control_chars("net.fetch", "contentType", &content_type)?;
 
         let method = method.to_uppercase();
         let response = self.http_request_with_content_type(url, &method, &body, &content_type)?;
@@ -1640,12 +1640,12 @@ fn parse_url_parts(url: &str) -> RtResult<ParsedUrlParts> {
         path = tail.to_string();
     }
 
-    reject_http_control_chars("scheme", scheme)?;
-    reject_http_control_chars("host", &host)?;
-    reject_http_control_chars("port", &port)?;
-    reject_http_control_chars("path", &path)?;
-    reject_http_control_chars("query", &query)?;
-    reject_http_control_chars("fragment", &fragment)?;
+    reject_http_control_chars("net.parseUrl", "scheme", scheme)?;
+    reject_http_control_chars("net.parseUrl", "host", &host)?;
+    reject_http_control_chars("net.parseUrl", "port", &port)?;
+    reject_http_control_chars("net.parseUrl", "path", &path)?;
+    reject_http_control_chars("net.parseUrl", "query", &query)?;
+    reject_http_control_chars("net.parseUrl", "fragment", &fragment)?;
 
     Ok(ParsedUrlParts {
         scheme: scheme.to_string(),
@@ -1657,14 +1657,14 @@ fn parse_url_parts(url: &str) -> RtResult<ParsedUrlParts> {
     })
 }
 
-fn reject_http_control_chars(component: &str, value: &str) -> RtResult<()> {
+fn reject_http_control_chars(api: &str, component: &str, value: &str) -> RtResult<()> {
     if value
         .chars()
         .any(|ch| ch.is_control() || matches!(ch, '\u{7f}'))
     {
         return Err(RtError::new(
             RtErrorKind::InvalidArgument,
-            format!("net.parseUrl {component} must not contain control characters"),
+            format!("{api} {component} must not contain control characters"),
         ));
     }
     Ok(())

--- a/skepart/tests/host.rs
+++ b/skepart/tests/host.rs
@@ -1341,7 +1341,7 @@ fn noop_host_rejects_urls_with_http_control_character_injection() {
     assert!(
         injected_path
             .message
-            .contains("path must not contain control characters"),
+            .contains("net.parseUrl path must not contain control characters"),
         "unexpected message: {}",
         injected_path.message
     );
@@ -1356,7 +1356,7 @@ fn noop_host_rejects_urls_with_http_control_character_injection() {
     assert!(
         injected_host
             .message
-            .contains("host must not contain control characters"),
+            .contains("net.parseUrl host must not contain control characters"),
         "unexpected message: {}",
         injected_host.message
     );
@@ -1378,7 +1378,7 @@ fn noop_host_rejects_fetch_method_and_content_type_control_chars() {
     assert!(
         injected_method
             .message
-            .contains("method must not contain control characters"),
+            .contains("net.fetch method must not contain control characters"),
         "unexpected message: {}",
         injected_method.message
     );
@@ -1400,7 +1400,7 @@ fn noop_host_rejects_fetch_method_and_content_type_control_chars() {
     assert!(
         injected_content_type
             .message
-            .contains("contentType must not contain control characters"),
+            .contains("net.fetch contentType must not contain control characters"),
         "unexpected message: {}",
         injected_content_type.message
     );

--- a/skepart/tests/host.rs
+++ b/skepart/tests/host.rs
@@ -1384,18 +1384,12 @@ fn noop_host_rejects_fetch_method_and_content_type_control_chars() {
     );
 
     let content_type_options = skepart::RtMap::new();
-    content_type_options.insert(
-        "method",
-        skepart::RtValue::String(RtString::from("POST")),
-    );
+    content_type_options.insert("method", skepart::RtValue::String(RtString::from("POST")));
     content_type_options.insert(
         "contentType",
         skepart::RtValue::String(RtString::from("text/plain\r\nInjected: yes")),
     );
-    content_type_options.insert(
-        "body",
-        skepart::RtValue::String(RtString::from("payload")),
-    );
+    content_type_options.insert("body", skepart::RtValue::String(RtString::from("payload")));
     let injected_content_type = host
         .net_fetch("http://example.com/", &content_type_options)
         .expect_err("control characters in contentType should fail");

--- a/skepart/tests/host.rs
+++ b/skepart/tests/host.rs
@@ -1363,6 +1363,56 @@ fn noop_host_rejects_urls_with_http_control_character_injection() {
 }
 
 #[test]
+fn noop_host_rejects_fetch_method_and_content_type_control_chars() {
+    let mut host = NoopHost::default();
+
+    let method_options = skepart::RtMap::new();
+    method_options.insert(
+        "method",
+        skepart::RtValue::String(RtString::from("GET\r\nInjected: yes")),
+    );
+    let injected_method = host
+        .net_fetch("http://example.com/", &method_options)
+        .expect_err("control characters in method should fail");
+    assert_eq!(injected_method.kind, skepart::RtErrorKind::InvalidArgument);
+    assert!(
+        injected_method
+            .message
+            .contains("method must not contain control characters"),
+        "unexpected message: {}",
+        injected_method.message
+    );
+
+    let content_type_options = skepart::RtMap::new();
+    content_type_options.insert(
+        "method",
+        skepart::RtValue::String(RtString::from("POST")),
+    );
+    content_type_options.insert(
+        "contentType",
+        skepart::RtValue::String(RtString::from("text/plain\r\nInjected: yes")),
+    );
+    content_type_options.insert(
+        "body",
+        skepart::RtValue::String(RtString::from("payload")),
+    );
+    let injected_content_type = host
+        .net_fetch("http://example.com/", &content_type_options)
+        .expect_err("control characters in contentType should fail");
+    assert_eq!(
+        injected_content_type.kind,
+        skepart::RtErrorKind::InvalidArgument
+    );
+    assert!(
+        injected_content_type
+            .message
+            .contains("contentType must not contain control characters"),
+        "unexpected message: {}",
+        injected_content_type.message
+    );
+}
+
+#[test]
 fn noop_host_supports_basic_fetch_over_loopback() {
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind http listener");
     let addr = listener.local_addr().expect("listener addr");


### PR DESCRIPTION
## Summary
Fixes [#20](https://github.com/AayushMainali-Github/skepa-lang/issues/20): `net.fetch` `method` and `contentType` option fields are rejected when they contain HTTP control characters (including CR/LF), matching URL-part validation.

## Area
- runtime
- tests

## Why
URL components were already sanitized, but request option fields were interpolated into the request line/headers without the same check, allowing header injection.

## What Changed
- apply `reject_http_control_chars` to `method` and `contentType` before building the HTTP request
- add a host regression test for CR/LF injection attempts

## Validation
- [x] `cargo fmt --all`
- [x] focused tests for touched area
- [ ] `cargo test --workspace` when relevant (CI)

Commands run:
```bash
cargo fmt --all
```

## Notes for Review
Valid methods/content types are unchanged; only control characters are rejected.