### PR TITLE
fix(runtime): avoid overflow in random.int span

### DIFF
--- a/skepart/src/host.rs
+++ b/skepart/src/host.rs
@@ -730,8 +730,9 @@ impl RtHost for NoopHost {
             .random_state
             .wrapping_mul(6364136223846793005)
             .wrapping_add(1);
-        let span = (max - min + 1) as u64;
-        Ok(min + (self.random_state % span) as i64)
+        let span = (i128::from(max) - i128::from(min) + 1) as u128;
+        let offset = (u128::from(self.random_state) % span) as i64;
+        Ok(min + offset)
     }
 
     fn random_float(&mut self) -> RtResult<f64> {
@@ -2081,5 +2082,14 @@ mod tests {
             read_line_trimmed(&mut Cursor::new("")).expect("empty"),
             RtString::from("")
         );
+    }
+
+    #[test]
+    fn random_int_handles_full_non_negative_i64_span() {
+        let mut host = NoopHost::default();
+        let value = host
+            .random_int(0, i64::MAX)
+            .expect("large inclusive range should not overflow");
+        assert!((0..=i64::MAX).contains(&value));
     }
 }

--- a/skepart/src/host.rs
+++ b/skepart/src/host.rs
@@ -731,8 +731,8 @@ impl RtHost for NoopHost {
             .wrapping_mul(6364136223846793005)
             .wrapping_add(1);
         let span = (i128::from(max) - i128::from(min) + 1) as u128;
-        let offset = (u128::from(self.random_state) % span) as i64;
-        Ok(min + offset)
+        let offset = (u128::from(self.random_state) % span) as i128;
+        Ok((i128::from(min) + offset) as i64)
     }
 
     fn random_float(&mut self) -> RtResult<f64> {
@@ -2091,5 +2091,15 @@ mod tests {
             .random_int(0, i64::MAX)
             .expect("large inclusive range should not overflow");
         assert!((0..=i64::MAX).contains(&value));
+    }
+
+    #[test]
+    fn random_int_handles_full_i64_span_without_debug_overflow() {
+        let mut host = NoopHost::default();
+        host.random_state = 0x8000_0000_0000_0000;
+        let value = host
+            .random_int(i64::MIN, i64::MAX)
+            .expect("full i64 inclusive range should not overflow");
+        assert!((i64::MIN..=i64::MAX).contains(&value));
     }
 }

--- a/skepart/src/host.rs
+++ b/skepart/src/host.rs
@@ -2095,8 +2095,10 @@ mod tests {
 
     #[test]
     fn random_int_handles_full_i64_span_without_debug_overflow() {
-        let mut host = NoopHost::default();
-        host.random_state = 0x8000_0000_0000_0000;
+        let mut host = NoopHost {
+            random_state: 0x8000_0000_0000_0000,
+            ..NoopHost::default()
+        };
         let value = host
             .random_int(i64::MIN, i64::MAX)
             .expect("full i64 inclusive range should not overflow");


### PR DESCRIPTION
## Summary
Fixes [#25](https://github.com/AayushMainali-Github/skepa-lang/issues/25): `random.int` inclusive-range span is computed with wider arithmetic so large ranges no longer overflow `i64`.

## Area
- runtime

## Why
`(max - min + 1)` in `i64` overflowed for wide inclusive ranges (for example `0..=i64::MAX`), producing wrong or trapping modulo behavior.

## What Changed
- compute the span using wider integer arithmetic in `NoopHost::random_int`

## Validation
- [x] `cargo fmt --all`
- [ ] focused tests for touched area
- [ ] `cargo test --workspace` when relevant (CI)

Commands run:
```bash
cargo fmt --all
```

## Notes for Review
Semantics for small in-range spans are unchanged.