### PR TITLE
fix(scripts): avoid overwriting $args in install.ps1

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -11,12 +11,12 @@ if (-not (Get-Command cargo -ErrorAction SilentlyContinue)) {
 
 $root = Split-Path -Parent $PSScriptRoot
 
-$args = @("install")
+$cargoArgs = @("install")
 if ($Force) {
-  $args += "--force"
+  $cargoArgs += "--force"
 }
 
 Write-Host "Installing skepac..."
-& cargo @args --path (Join-Path $root "skepac")
+& cargo @cargoArgs --path (Join-Path $root "skepac")
 
-Write-Host "Done. Ensure `%USERPROFILE%\.cargo\bin` is on PATH."
+Write-Host "Done. Ensure `$env:USERPROFILE\.cargo\bin` is on PATH."


### PR DESCRIPTION
## Summary
Fixes [#46](https://github.com/AayushMainali-Github/skepa-lang/issues/46): `scripts/install.ps1` no longer overwrites PowerShell's automatic `$args` variable, and the PATH hint uses PowerShell syntax.

## Area
- cli

## Why
Assigning to `$args` clobbers a built-in automatic variable. The finish message also printed a cmd-style `%USERPROFILE%` hint that is wrong in PowerShell.

## What Changed
- rename the cargo argument array to `$cargoArgs`
- print `$env:USERPROFILE\.cargo\bin` in the completion message

## Validation
- [x] script review
- [ ] `cargo fmt --all` (N/A)
- [ ] `cargo test --workspace` when relevant (N/A)

Commands run:
```bash
# PowerShell script-only change
```

## Notes for Review
Install behavior is unchanged aside from argument handling and messaging.