### PR TITLE
docs(security): add vulnerability reporting policy

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,13 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in skepa-lang, please report it privately.
+
+**Do not** open a public GitHub issue for security vulnerabilities.
+
+Prefer [GitHub Security Advisories](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability) (private vulnerability reporting) on this repository:
+
+https://github.com/AayushMainali-Github/skepa-lang/security/advisories/new
+
+Maintainers will review private reports and coordinate disclosure. Thank you for helping keep skepa-lang and its users safe.


### PR DESCRIPTION
## Summary
Fixes [#48](https://github.com/AayushMainali-Github/skepa-lang/issues/48): adds a short vulnerability reporting policy under `.github/SECURITY.md`.

## Area
- docs

## Why
The repository had no documented security contact or private disclosure process.

## What Changed
- add `.github/SECURITY.md` directing reporters to GitHub private vulnerability reporting / advisories

## Validation
- [x] docs review
- [ ] `cargo fmt --all` (N/A)
- [ ] `cargo test --workspace` when relevant (N/A)

Commands run:
```bash
# documentation-only change
```

## Notes for Review
No code or runtime behavior changes.