### PR TITLE
docs: align clippy instructions with CI -D warnings

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -75,7 +75,7 @@ Before opening a PR, run:
 
 ```bash
 cargo fmt --all
-cargo clippy --workspace --all-targets -- -D warnings
+cargo clippy --workspace --all-targets --all-features -- -D warnings
 cargo test --workspace
 ```
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -75,7 +75,7 @@ Before opening a PR, run:
 
 ```bash
 cargo fmt --all
-cargo clippy --workspace --all-targets
+cargo clippy --workspace --all-targets -- -D warnings
 cargo test --workspace
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ After code changes, run:
 
 ```bash
 cargo fmt --all
-cargo clippy --workspace --all-targets -- -D warnings
+cargo clippy --workspace --all-targets --all-features -- -D warnings
 cargo test --workspace
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ After code changes, run:
 
 ```bash
 cargo fmt --all
-cargo clippy --workspace --all-targets
+cargo clippy --workspace --all-targets -- -D warnings
 cargo test --workspace
 ```
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -243,7 +243,7 @@ After every code change, run:
 
 ```bash
 cargo fmt --all
-cargo clippy --workspace --all-targets
+cargo clippy --workspace --all-targets -- -D warnings
 cargo test --workspace
 ```
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -243,7 +243,7 @@ After every code change, run:
 
 ```bash
 cargo fmt --all
-cargo clippy --workspace --all-targets -- -D warnings
+cargo clippy --workspace --all-targets --all-features -- -D warnings
 cargo test --workspace
 ```
 


### PR DESCRIPTION
## Summary
Fixes [#50](https://github.com/AayushMainali-Github/skepa-lang/issues/50): contributor docs now match CI Clippy flags, including `--all-features` and `-D warnings`.

## Area
- docs
- ci

## Why
CI runs `cargo clippy --workspace --all-targets --all-features -- -D warnings`. Contributor docs previously omitted those flags, so a clean local Clippy run could still fail in CI.

## What Changed
- update the documented Clippy command in `AGENTS.md`, `.github/CONTRIBUTING.md`, and `TESTING.md` to `cargo clippy --workspace --all-targets --all-features -- -D warnings`

## Validation
- [x] docs review against `.github/workflows/ci.yml`
- [ ] `cargo fmt --all` (N/A — docs only)
- [ ] `cargo test --workspace` when relevant (N/A)

Commands run:
```bash
# documentation-only change; verified against CI Clippy step
```

## Notes for Review
Docs-only. Matches the current CI Clippy invocation exactly.