### PR TITLE
docs(agents): point contributing guide at .github path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,4 +64,4 @@ When changing user-visible commands, testing patterns, or architecture boundarie
 - `README.md`
 - `TESTING.md`
 - `AGENTS.md`
-- `CONTRIBUTING.md` if contributor workflow changes
+- `.github/CONTRIBUTING.md` if contributor workflow changes


### PR DESCRIPTION
## Summary
Fixes [#51](https://github.com/AayushMainali-Github/skepa-lang/issues/51): `AGENTS.md` now points at `.github/CONTRIBUTING.md`, matching the real file location and `README.md`.

## Area
- docs

## Why
`AGENTS.md` listed `CONTRIBUTING.md` at the repo root, but that file does not exist there. The contributor guide lives at `.github/CONTRIBUTING.md`.

## What Changed
- update the docs list in `AGENTS.md` to `.github/CONTRIBUTING.md`

## Validation
- [x] docs path check
- [ ] `cargo fmt --all` (N/A — docs only)
- [ ] `cargo test --workspace` when relevant (N/A)

Commands run:
```bash
# documentation-only change
```

## Notes for Review
Docs-only one-line path fix. Touches a different part of `AGENTS.md` than the Clippy docs PR (#85 / issue #50).