### PR TITLE
fix(ir): avoid debug panics in integer const folding

### DIFF
--- a/skeplib/src/ir/opt/const_fold.rs
+++ b/skeplib/src/ir/opt/const_fold.rs
@@ -197,7 +197,7 @@ fn resolve_const(
 
 fn eval_unary(op: UnaryOp, value: &ConstValue) -> Option<ConstValue> {
     match (op, value) {
-        (UnaryOp::Neg, ConstValue::Int(v)) => Some(ConstValue::Int(-v)),
+        (UnaryOp::Neg, ConstValue::Int(v)) => Some(ConstValue::Int(v.wrapping_neg())),
         (UnaryOp::Neg, ConstValue::Float(v)) => Some(ConstValue::Float(-v)),
         (UnaryOp::Not, ConstValue::Bool(v)) => Some(ConstValue::Bool(!v)),
         (UnaryOp::BitNot, ConstValue::Int(v)) => Some(ConstValue::Int(!v)),
@@ -207,13 +207,25 @@ fn eval_unary(op: UnaryOp, value: &ConstValue) -> Option<ConstValue> {
 
 fn eval_binary(op: BinaryOp, left: &ConstValue, right: &ConstValue) -> Option<ConstValue> {
     match (op, left, right) {
-        (BinaryOp::Add, ConstValue::Int(a), ConstValue::Int(b)) => Some(ConstValue::Int(a + b)),
-        (BinaryOp::Sub, ConstValue::Int(a), ConstValue::Int(b)) => Some(ConstValue::Int(a - b)),
-        (BinaryOp::Mul, ConstValue::Int(a), ConstValue::Int(b)) => Some(ConstValue::Int(a * b)),
+        (BinaryOp::Add, ConstValue::Int(a), ConstValue::Int(b)) => {
+            Some(ConstValue::Int(a.wrapping_add(*b)))
+        }
+        (BinaryOp::Sub, ConstValue::Int(a), ConstValue::Int(b)) => {
+            Some(ConstValue::Int(a.wrapping_sub(*b)))
+        }
+        (BinaryOp::Mul, ConstValue::Int(a), ConstValue::Int(b)) => {
+            Some(ConstValue::Int(a.wrapping_mul(*b)))
+        }
         (BinaryOp::Div, ConstValue::Int(_), ConstValue::Int(0)) => None,
-        (BinaryOp::Div, ConstValue::Int(a), ConstValue::Int(b)) => Some(ConstValue::Int(a / b)),
+        (BinaryOp::Div, ConstValue::Int(a), ConstValue::Int(-1)) if *a == i64::MIN => None,
+        (BinaryOp::Div, ConstValue::Int(a), ConstValue::Int(b)) => {
+            Some(ConstValue::Int(a.wrapping_div(*b)))
+        }
         (BinaryOp::Mod, ConstValue::Int(_), ConstValue::Int(0)) => None,
-        (BinaryOp::Mod, ConstValue::Int(a), ConstValue::Int(b)) => Some(ConstValue::Int(a % b)),
+        (BinaryOp::Mod, ConstValue::Int(a), ConstValue::Int(-1)) if *a == i64::MIN => None,
+        (BinaryOp::Mod, ConstValue::Int(a), ConstValue::Int(b)) => {
+            Some(ConstValue::Int(a.wrapping_rem(*b)))
+        }
         (BinaryOp::BitAnd, ConstValue::Int(a), ConstValue::Int(b)) => Some(ConstValue::Int(a & b)),
         (BinaryOp::BitOr, ConstValue::Int(a), ConstValue::Int(b)) => Some(ConstValue::Int(a | b)),
         (BinaryOp::BitXor, ConstValue::Int(a), ConstValue::Int(b)) => Some(ConstValue::Int(a ^ b)),

--- a/skeplib/tests/ir_const_fold_overflow.rs
+++ b/skeplib/tests/ir_const_fold_overflow.rs
@@ -18,9 +18,11 @@ fn main() -> Int {
 
 #[test]
 fn const_fold_does_not_fold_min_div_neg_one() {
+    // Avoid writing i64::MIN as a positive token (out of range for Int literals).
+    // Fold MAX+1 to MIN first, then ensure MIN / -1 stays unfolded.
     let source = r#"
 fn main() -> Int {
-  return -9223372036854775808 / -1;
+  return (9223372036854775807 + 1) / -1;
 }
 "#;
 

--- a/skeplib/tests/ir_const_fold_overflow.rs
+++ b/skeplib/tests/ir_const_fold_overflow.rs
@@ -1,0 +1,33 @@
+use skeplib::ir::{self, PrettyIr};
+
+#[test]
+fn const_fold_wraps_max_plus_one_without_debug_panic() {
+    let source = r#"
+fn main() -> Int {
+  return 9223372036854775807 + 1;
+}
+"#;
+
+    let program = ir::lowering::compile_source(source).expect("IR lowering should succeed");
+    let printed = PrettyIr::new(&program).to_string();
+    assert!(
+        printed.contains(&format!("Int({})", i64::MIN)),
+        "expected wrapped MIN constant, got:\n{printed}"
+    );
+}
+
+#[test]
+fn const_fold_does_not_fold_min_div_neg_one() {
+    let source = r#"
+fn main() -> Int {
+  return -9223372036854775808 / -1;
+}
+"#;
+
+    let program = ir::lowering::compile_source(source).expect("IR lowering should succeed");
+    let printed = PrettyIr::new(&program).to_string();
+    assert!(
+        printed.contains("Binary") && printed.contains("Div"),
+        "MIN / -1 must stay unfolded, got:\n{printed}"
+    );
+}


### PR DESCRIPTION
## Summary
Fixes [#32](https://github.com/AayushMainali-Github/skepa-lang/issues/32): integer const-folding uses wrapping arithmetic (and skips `MIN / -1`) so debug builds no longer panic the compiler.

## Area
- ir

## Why
Const-fold used overflowing `+`/`/`/`%`/`-`, which can abort the process in debug for overflow or `i64::MIN / -1`.

## What Changed
- use `wrapping_*` for integer add/sub/mul/div/rem/neg in `skeplib/src/ir/opt/const_fold.rs`
- refuse to fold `MIN / -1` and `MIN % -1`

## Validation
- [x] `cargo fmt --all`
- [x] `cargo fmt --all --check`
- [ ] focused tests for touched area
- [ ] `cargo test --workspace` when relevant (CI)

Commands run:
```bash
cargo fmt --all
cargo fmt --all --check
```

## Notes for Review
Aligns folding with wrapping native integer semantics for ordinary overflow; `MIN/-1` stays unfolded.