### PR TITLE
fix(ir): do not strength-reduce float plus/minus zero

### DIFF
--- a/skeplib/src/ir/opt/strength_reduce.rs
+++ b/skeplib/src/ir/opt/strength_reduce.rs
@@ -63,16 +63,13 @@ fn reduce_add(
     right: Operand,
 ) -> Option<Instr> {
     match (&left, &right) {
-        (_, Operand::Const(ConstValue::Int(0))) | (_, Operand::Const(ConstValue::Float(0.0))) => {
-            Some(Instr::Copy { dst, ty, src: left })
-        }
-        (Operand::Const(ConstValue::Int(0)), _) | (Operand::Const(ConstValue::Float(0.0)), _) => {
-            Some(Instr::Copy {
-                dst,
-                ty,
-                src: right,
-            })
-        }
+        // Float ±0.0 is not a safe identity because of signed zero.
+        (_, Operand::Const(ConstValue::Int(0))) => Some(Instr::Copy { dst, ty, src: left }),
+        (Operand::Const(ConstValue::Int(0)), _) => Some(Instr::Copy {
+            dst,
+            ty,
+            src: right,
+        }),
         _ => None,
     }
 }
@@ -84,9 +81,7 @@ fn reduce_sub(
     right: Operand,
 ) -> Option<Instr> {
     match right {
-        Operand::Const(ConstValue::Int(0)) | Operand::Const(ConstValue::Float(0.0)) => {
-            Some(Instr::Copy { dst, ty, src: left })
-        }
+        Operand::Const(ConstValue::Int(0)) => Some(Instr::Copy { dst, ty, src: left }),
         _ => None,
     }
 }

--- a/skeplib/tests/ir_strength_float_zero.rs
+++ b/skeplib/tests/ir_strength_float_zero.rs
@@ -1,0 +1,43 @@
+use skeplib::ir::{self, PrettyIr};
+
+#[test]
+fn strength_reduce_does_not_elide_float_plus_or_minus_zero() {
+    let source = r#"
+fn keep_add(x: Float) -> Float {
+  return x + 0.0;
+}
+
+fn keep_sub(x: Float) -> Float {
+  return x - 0.0;
+}
+
+fn main() -> Float {
+  return keep_add(1.5) + keep_sub(-0.0);
+}
+"#;
+
+    let program = ir::lowering::compile_source(source).expect("IR lowering should succeed");
+    let printed = PrettyIr::new(&program).to_string();
+    assert!(
+        printed.contains("Add") || printed.contains("Binary"),
+        "float x + 0.0 must not be reduced away, got:\n{printed}"
+    );
+    assert!(
+        printed.contains("Sub") || printed.contains("Binary"),
+        "float x - 0.0 must not be reduced away, got:\n{printed}"
+    );
+    // A pure Copy of the parameter alone would mean the float zero identity fired.
+    let keep_add_block = printed
+        .split("fn keep_add")
+        .nth(1)
+        .unwrap_or("")
+        .split("fn keep_sub")
+        .next()
+        .unwrap_or("");
+    assert!(
+        !keep_add_block.contains("Copy")
+            || keep_add_block.contains("Add")
+            || keep_add_block.contains("Binary"),
+        "keep_add should retain an add, got:\n{keep_add_block}"
+    );
+}


### PR DESCRIPTION
## Summary
Fixes [#42](https://github.com/AayushMainali-Github/skepa-lang/issues/42): strength reduction no longer treats float `±0.0` as an add/sub identity, preserving signed-zero behavior.

## Area
- ir

## Why
Rust/`f64` treat `0.0 == -0.0`, so rewriting `x + 0.0` to `x` can keep a negative zero where IEEE addition would produce `+0.0`.

## What Changed
- keep float `+ 0.0` / `- 0.0` reductions out of `reduce_add` / `reduce_sub` in `skeplib/src/ir/opt/strength_reduce.rs`
- integer `±0` identities are unchanged

## Validation
- [x] `cargo fmt --all`
- [x] `cargo fmt --all --check`
- [ ] focused tests for touched area
- [ ] `cargo test --workspace` when relevant (CI)

Commands run:
```bash
cargo fmt --all
cargo fmt --all --check
```

## Notes for Review
Only float zero identities are disabled; int strength reduction is unchanged.