### PR TITLE
fix(ir): keep VecDelete and trapping ops alive in DCE

### DIFF
--- a/skeplib/src/ir/opt/dce.rs
+++ b/skeplib/src/ir/opt/dce.rs
@@ -63,27 +63,40 @@ fn instr_dst(instr: &Instr) -> Option<crate::ir::TempId> {
 }
 
 fn is_pure(instr: &Instr) -> bool {
-    matches!(
-        instr,
+    match instr {
         Instr::Const { .. }
-            | Instr::Copy { .. }
-            | Instr::Unary { .. }
-            | Instr::Binary { .. }
-            | Instr::Compare { .. }
-            | Instr::Logic { .. }
-            | Instr::LoadGlobal { .. }
-            | Instr::LoadLocal { .. }
-            | Instr::MakeArray { .. }
-            | Instr::MakeArrayRepeat { .. }
-            | Instr::VecNew { .. }
-            | Instr::VecLen { .. }
-            | Instr::ArrayGet { .. }
-            | Instr::VecGet { .. }
-            | Instr::VecDelete { .. }
-            | Instr::MakeStruct { .. }
-            | Instr::StructGet { .. }
-            | Instr::MakeClosure { .. }
-    )
+        | Instr::Copy { .. }
+        | Instr::Compare { .. }
+        | Instr::Logic { .. }
+        | Instr::LoadGlobal { .. }
+        | Instr::LoadLocal { .. }
+        | Instr::MakeArray { .. }
+        | Instr::MakeArrayRepeat { .. }
+        | Instr::VecNew { .. }
+        | Instr::VecLen { .. }
+        | Instr::MakeStruct { .. }
+        | Instr::StructGet { .. }
+        | Instr::MakeClosure { .. } => true,
+        // Negation can trap on i64::MIN in debug builds.
+        Instr::Unary {
+            op: crate::ir::UnaryOp::Neg,
+            ..
+        } => false,
+        Instr::Unary { .. } => true,
+        // Division/remainder and shifts can trap at runtime.
+        Instr::Binary {
+            op:
+                crate::ir::BinaryOp::Div
+                | crate::ir::BinaryOp::Mod
+                | crate::ir::BinaryOp::Shl
+                | crate::ir::BinaryOp::Shr,
+            ..
+        } => false,
+        Instr::Binary { .. } => true,
+        // Indexing may trap; VecDelete mutates the vector.
+        Instr::ArrayGet { .. } | Instr::VecGet { .. } | Instr::VecDelete { .. } => false,
+        _ => false,
+    }
 }
 
 fn collect_terminator_uses(term: &Terminator, live: &mut HashSet<crate::ir::TempId>) {

--- a/skeplib/tests/ir_dce_effects.rs
+++ b/skeplib/tests/ir_dce_effects.rs
@@ -1,0 +1,40 @@
+use skeplib::ir::{self, PrettyIr};
+
+#[test]
+fn dce_keeps_unused_vec_delete() {
+    let source = r#"
+import vec;
+
+fn main() -> Int {
+  let xs: Vec[Int] = vec.new();
+  vec.push(xs, 1);
+  vec.push(xs, 2);
+  let _removed = vec.delete(xs, 0);
+  return vec.len(xs);
+}
+"#;
+
+    let program = ir::lowering::compile_source(source).expect("IR lowering should succeed");
+    let printed = PrettyIr::new(&program).to_string();
+    assert!(
+        printed.contains("VecDelete"),
+        "unused VecDelete must survive DCE, got:\n{printed}"
+    );
+}
+
+#[test]
+fn dce_keeps_unused_trapping_division() {
+    let source = r#"
+fn main() -> Int {
+  let _dead = 1 / 0;
+  return 1;
+}
+"#;
+
+    let program = ir::lowering::compile_source(source).expect("IR lowering should succeed");
+    let printed = PrettyIr::new(&program).to_string();
+    assert!(
+        printed.contains("Binary") && printed.contains("Div"),
+        "unused trapping 1/0 must survive DCE, got:\n{printed}"
+    );
+}


### PR DESCRIPTION
## Summary
Fixes [#15](https://github.com/AayushMainali-Github/skepa-lang/issues/15): DCE no longer treats `VecDelete` and trapping ops as pure, so their side effects are kept.

## Area
- ir

## Why
`is_pure` marked `VecDelete`, indexing, and trapping arithmetic as removable. Unused results could drop deletes or ops that trap at runtime.

## What Changed
- mark `VecDelete`, `ArrayGet`, and `VecGet` impure in `skeplib/src/ir/opt/dce.rs`
- mark `Neg`, `Div`, `Mod`, `Shl`, and `Shr` impure so trapping cases are not deleted

## Validation
- [x] `cargo fmt --all`
- [x] `cargo fmt --all --check`
- [ ] focused tests for touched area
- [ ] `cargo test --workspace` when relevant (CI)

Commands run:
```bash
cargo fmt --all
cargo fmt --all --check
```

## Notes for Review
Non-trapping pure ops (e.g. add/mul without trap) can still be DCE'd when unused.