### PR TITLE
fix(codegen): use unordered fcmp for float !=

### DIFF
--- a/skeplib/src/codegen/llvm/compare.rs
+++ b/skeplib/src/codegen/llvm/compare.rs
@@ -104,7 +104,7 @@ pub fn emit_compare(
         crate::ir::IrType::Float => {
             let pred = match op {
                 CmpOp::Eq => "oeq",
-                CmpOp::Ne => "one",
+                CmpOp::Ne => "une",
                 CmpOp::Lt => "olt",
                 CmpOp::Le => "ole",
                 CmpOp::Gt => "ogt",

--- a/skeplib/tests/native_codegen_project.rs
+++ b/skeplib/tests/native_codegen_project.rs
@@ -97,3 +97,30 @@ fn main() -> Int {
     assert!(llvm_ir.contains("call ptr @skp_rt_call_builtin("));
     assert!(!llvm_ir.contains("call ptr @skp_rt_builtin_str_slice("));
 }
+
+#[test]
+fn llvm_codegen_emits_unordered_fcmp_for_float_inequality() {
+    let source = r#"
+fn main() -> Int {
+  let x = 1.5;
+  let y = 2.0;
+  if (x != y) {
+    return 1;
+  }
+  return 0;
+}
+"#;
+
+    let program = ir::lowering::compile_source(source).expect("IR lowering should succeed");
+    let llvm_ir =
+        codegen::compile_program_to_llvm_ir(&program).expect("LLVM lowering should succeed");
+
+    assert!(
+        llvm_ir.contains("fcmp une double"),
+        "expected unordered float != lowering, got:\n{llvm_ir}"
+    );
+    assert!(
+        !llvm_ir.contains("fcmp one double"),
+        "ordered fcmp one must not be used for float !="
+    );
+}


### PR DESCRIPTION
## Summary
Fixes [#31](https://github.com/AayushMainali-Github/skepa-lang/issues/31): float `!=` now lowers to unordered LLVM `fcmp une`, matching interpreter/`f64` inequality with NaN.

## Area
- codegen

## Why
Float `!=` used ordered `fcmp one`, so `NaN != x` was false in native code while the interpreter treats NaN inequality as true.

## What Changed
- change float `CmpOp::Ne` from `one` to `une` in `skeplib/src/codegen/llvm/compare.rs`

## Validation
- [x] `cargo fmt --all`
- [x] `cargo fmt --all --check`
- [ ] focused tests for touched area
- [ ] `cargo test --workspace` when relevant (CI)

Commands run:
```bash
cargo fmt --all
cargo fmt --all --check
```

## Notes for Review
Float `==` stays `oeq`; only `!=` changes to unordered.