### PR TITLE
fix(runtime): accept optional fractional seconds in datetime.parseUnix

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -1362,8 +1362,9 @@ Behavior:
 - `datetime.nowUnix` / `nowMillis` read the host system clock.
 
 Notes:
-- `datetime.parseUnix` expects `YYYY-MM-DDTHH:MM:SSZ`.
+- `datetime.parseUnix` accepts `YYYY-MM-DDTHH:MM:SSZ` (whole seconds) and `YYYY-MM-DDTHH:MM:SS.mmmZ` (optional fractional seconds). Fractional seconds are parsed and discarded; the returned Unix timestamp has whole-second precision.
 - `datetime.parseUnix` returns `Ok(Int)` on valid input and `Err(String)` on invalid input.
+- Strings produced by `datetime.fromMillis` (which include a `.mmm` suffix when milliseconds are non-zero) are accepted by `datetime.parseUnix`, enabling correct round-trip parsing.
 
 ### 8.8 `random`
 

--- a/skepart/src/host.rs
+++ b/skepart/src/host.rs
@@ -1849,7 +1849,11 @@ fn parse_iso8601_utc(value: &str) -> RtResult<i64> {
     let mut time_parts = time.split(':');
     let hour: u32 = parse_part(time_parts.next(), "hour")?;
     let minute: u32 = parse_part(time_parts.next(), "minute")?;
-    let second: u32 = parse_part(time_parts.next(), "second")?;
+    // Strip optional fractional seconds (e.g. ".234" in "01.234") so that
+    // strings produced by datetime.fromMillis round-trip through parseUnix.
+    let raw_second = time_parts.next();
+    let second_str = raw_second.map(|s| s.split_once('.').map_or(s, |(w, _)| w));
+    let second: u32 = parse_part(second_str, "second")?;
     if time_parts.next().is_some() {
         return Err(RtError::new(
             RtErrorKind::InvalidArgument,

--- a/skepart/tests/host.rs
+++ b/skepart/tests/host.rs
@@ -349,10 +349,60 @@ fn noop_host_supports_print_and_time_defaults() {
 }
 
 #[test]
+fn datetime_from_millis_round_trips_through_parse_unix() {
+    // Regression: fromMillis emits fractional seconds (e.g. "1970-01-01T00:00:01.234Z")
+    // that parseUnix previously rejected with "invalid second".  After the fix,
+    // parseUnix strips the fractional part and returns the whole-second truncation.
+    let mut host = NoopHost::default();
+
+    // 1234 ms -> 1 whole second, 234 ms remainder
+    let s = host
+        .datetime_from_millis(1234)
+        .expect("fromMillis should succeed");
+    assert_eq!(s, RtString::from("1970-01-01T00:00:01.234Z"));
+    let ts = host
+        .datetime_parse_unix(s.as_str())
+        .expect("parseUnix must accept fromMillis output");
+    // Fractional seconds are discarded; whole-second part is 1.
+    assert_eq!(ts, 1);
+
+    // Zero milliseconds -> no fractional part in the formatted string.
+    let s0 = host
+        .datetime_from_millis(0)
+        .expect("fromMillis(0) should succeed");
+    assert_eq!(s0, RtString::from("1970-01-01T00:00:00Z"));
+    let ts0 = host
+        .datetime_parse_unix(s0.as_str())
+        .expect("parseUnix must accept fromMillis(0) output");
+    assert_eq!(ts0, 0);
+
+    // Exact multiple of 1000 ms -> whole seconds only, no fractional part.
+    let s_exact = host
+        .datetime_from_millis(60_000)
+        .expect("fromMillis(60_000) should succeed");
+    assert_eq!(s_exact, RtString::from("1970-01-01T00:01:00Z"));
+    let ts_exact = host
+        .datetime_parse_unix(s_exact.as_str())
+        .expect("parseUnix must accept fromMillis(60_000) output");
+    assert_eq!(ts_exact, 60);
+
+    // Large value with non-zero millis remainder.
+    let s_large = host
+        .datetime_from_millis(1_700_000_000_999)
+        .expect("fromMillis large should succeed");
+    let ts_large = host
+        .datetime_parse_unix(s_large.as_str())
+        .expect("parseUnix must accept large fromMillis output");
+    // parseUnix returns whole-second truncation.
+    assert_eq!(ts_large, 1_700_000_000);
+}
+
+#[test]
 fn recording_host_captures_output_and_overrides_services() {
     let mut host = RecordingHostBuilder::seeded().build();
     host.io_print("a").expect("print");
     host.io_println("b").expect("println");
+
     assert_eq!(host.output, "ab\n");
     assert_eq!(
         host.io_read_line().expect("read line"),


### PR DESCRIPTION
Fixes #89

## Summary

`datetime.fromMillis` formats timestamps as `YYYY-MM-DDTHH:MM:SS.mmmZ` when
the millisecond remainder is non-zero. `datetime.parseUnix` split the time on
`:`, producing a seconds token like `"01.234"`, then tried to parse it as a
bare `u32` — which always fails with `datetime.parseUnix invalid second`.

## Fix

Updated `parse_iso8601_utc` in `skepart/src/host.rs` to strip the optional
`.<frac>` suffix from the seconds token before parsing it as `u32`. Fractional
seconds are discarded; the returned Unix timestamp retains whole-second
precision.

## Changes

- **`skepart/src/host.rs`** — `parse_iso8601_utc` now accepts both
  `YYYY-MM-DDTHH:MM:SSZ` and `YYYY-MM-DDTHH:MM:SS.mmmZ`
- **`skepart/tests/host.rs`** — new regression test
  `datetime_from_millis_round_trips_through_parse_unix` covering zero millis,
  exact multiples of 1000, non-zero remainder (1234 ms), and a large timestamp
  (1_700_000_000_999 ms)
- **`DOCS.md`** — updated datetime section notes to document optional fractional
  second support and correct round-trip behaviour

## Testing
cargo fmt --all
cargo clippy --workspace --all-targets --all-features -- -D warnings
cargo test --workspace

