### PR TITLE
fix(cli): return EXIT_CODEGEN for IR lowering failures

### DIFF
--- a/skepac/src/commands.rs
+++ b/skepac/src/commands.rs
@@ -438,7 +438,7 @@ fn compile_project_graph_or_report(graph: &ModuleGraph, input: &str) -> Result<i
         Ok(program) => Ok(program),
         Err(message) => {
             eprintln!("[E-CODEGEN][codegen] {message}");
-            Err(EXIT_RESOLVE as i32)
+            Err(EXIT_CODEGEN as i32)
         }
     }
 }
@@ -451,7 +451,7 @@ fn compile_project_graph_unoptimized_or_report(
         Ok(program) => Ok(program),
         Err(message) => {
             eprintln!("[E-CODEGEN][codegen] {message}");
-            Err(EXIT_RESOLVE as i32)
+            Err(EXIT_CODEGEN as i32)
         }
     }
 }

--- a/skepac/tests/check_cli.rs
+++ b/skepac/tests/check_cli.rs
@@ -2857,6 +2857,35 @@ fn main() -> Int {
 }
 
 #[test]
+fn run_reports_ir_lowering_failure_as_codegen() {
+    let tmp = make_temp_dir("skepac_run_lowering_exit_codegen");
+    let source = write_temp_file(
+        &tmp,
+        "main.sk",
+        r#"
+let counter: Int = 0;
+fn main() -> Int {
+  counter = counter + 1;
+  return counter;
+}
+"#,
+    );
+
+    let output = Command::new(skepac_bin())
+        .arg("run")
+        .arg(&source)
+        .output()
+        .expect("run skepac run");
+
+    assert_cli_failure_class(&output, CliFailureClass::Codegen);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("assignment to unknown local `counter`"),
+        "stderr was: {stderr}"
+    );
+}
+
+#[test]
 fn build_obj_reports_toolchain_failure_cleanly() {
     let tmp = make_temp_dir("skepac_build_obj_no_toolchain");
     let source = tmp.join("main.sk");


### PR DESCRIPTION
Fixes #64

## Summary
- IR lowering failures were printed as `[E-CODEGEN]` but exited with `EXIT_RESOLVE` (15)
- Both optimized and unoptimized compile helpers now return `EXIT_CODEGEN` (12)
- Added CLI regression covering global-assign lowering failure

## Test plan
- [x] `cargo test -p skepac --test check_cli run_reports_ir_lowering_failure_as_codegen`
- [x] Reproduced: `skepac run` on global Ident assign previously exited 15 with codegen message