### PR TITLE
fix(parser): accept documented self: StructName receivers

### DIFF
--- a/skeplib/src/parser/mod.rs
+++ b/skeplib/src/parser/mod.rs
@@ -875,9 +875,29 @@ impl Parser {
             loop {
                 let param_name = self.expect_ident("Expected parameter name")?;
                 if param_name.lexeme == "self" {
+                    let ty = if self.at(TokenKind::Colon) {
+                        self.bump();
+                        let annotated =
+                            self.expect_type_name("Expected receiver type after `self:`")?;
+                        match &annotated {
+                            TypeName::Named(name) if name == receiver_ty => annotated,
+                            other => {
+                                self.diagnostics.error(
+                                    format!(
+                                        "Method `self` type must be `{receiver_ty}`, got {}",
+                                        other.as_str()
+                                    ),
+                                    param_name.span,
+                                );
+                                TypeName::Named(receiver_ty.to_string())
+                            }
+                        }
+                    } else {
+                        TypeName::Named(receiver_ty.to_string())
+                    };
                     params.push(Param {
                         name: "self".to_string(),
-                        ty: TypeName::Named(receiver_ty.to_string()),
+                        ty,
                     });
                 } else {
                     self.expect(TokenKind::Colon, "Expected `:` after parameter name")?;

--- a/skeplib/tests/frontend/parser/cases/structs.rs
+++ b/skeplib/tests/frontend/parser/cases/structs.rs
@@ -52,6 +52,50 @@ fn main() -> Int { return 0; }
 }
 
 #[test]
+fn parses_impl_methods_with_documented_self_type() {
+    let src = r#"
+struct Counter { n: Int }
+
+impl Counter {
+  fn bump(self: Counter) -> Int {
+    return self.n;
+  }
+
+  fn add(self: Counter, delta: Int) -> Int {
+    return self.n + delta;
+  }
+}
+
+fn main() -> Int {
+  let c = Counter { n: 1 };
+  return c.bump();
+}
+"#;
+    let program = parse_ok(src);
+    let method = &program.impls[0].methods[0];
+    assert_eq!(method.params[0].name, "self");
+    assert_eq!(method.params[0].ty, TypeName::Named("Counter".to_string()));
+    assert_eq!(program.impls[0].methods[1].params.len(), 2);
+}
+
+#[test]
+fn reports_mismatched_self_receiver_type() {
+    let src = r#"
+struct Counter { n: Int }
+
+impl Counter {
+  fn bump(self: Int) -> Int {
+    return self.n;
+  }
+}
+
+fn main() -> Int { return 0; }
+"#;
+    let diags = parse_err(src);
+    assert_has_diag(&diags, "Method `self` type must be `Counter`, got Int");
+}
+
+#[test]
 fn reports_invalid_struct_field_missing_colon() {
     let src = r#"
 struct User {


### PR DESCRIPTION
Fixes #68

## Summary
- Parser now accepts optional `self: StructName` on impl methods, matching DOCS
- Bare `self` still works; annotated type must match the impl target
- Added parser regression tests for valid and mismatched receiver types

## Test plan
- [x] `cargo test -p skeplib --test frontend_parser_suite self_`
- [x] Reproduced: `fn bump(self: Counter)` previously failed to parse