### PR TITLE
fix(sema): require Result ? ok-type compatibility

### DIFF
--- a/skeplib/src/sema/expr.rs
+++ b/skeplib/src/sema/expr.rs
@@ -472,10 +472,18 @@ impl Checker {
             (
                 TypeInfo::Result { ok, err },
                 TypeInfo::Result {
-                    ok: _,
+                    ok: expected_ok,
                     err: expected_err,
                 },
             ) => {
+                if !Self::types_compatible(&ok, &expected_ok) {
+                    self.error(format!(
+                        "`?` result ok type mismatch: expression has {}, but the enclosing function returns {}",
+                        display_type(&ok),
+                        display_type(&expected_ok)
+                    ));
+                    return TypeInfo::Unknown;
+                }
                 if !Self::types_compatible(&err, &expected_err) {
                     self.error(format!(
                         "`?` result error type mismatch: expression has {}, but the enclosing function returns {}",

--- a/skeplib/tests/frontend/sema/cases/core.rs
+++ b/skeplib/tests/frontend/sema/cases/core.rs
@@ -1729,3 +1729,20 @@ fn main() -> Int {
     assert!(result.has_errors);
     assert_has_diag(&diags, "`?` option value type mismatch");
 }
+
+#[test]
+fn sema_rejects_result_try_ok_type_mismatch() {
+    let src = r#"
+fn bad(x: Result[Int, String]) -> Result[Float, String] {
+  let v = x?;
+  return Ok(1.0);
+}
+
+fn main() -> Int {
+  return 0;
+}
+"#;
+    let (result, diags) = analyze_source(src);
+    assert!(result.has_errors);
+    assert_has_diag(&diags, "`?` result ok type mismatch");
+}


### PR DESCRIPTION
Fixes #58

## Summary
- `?` on `Result` now checks ok-type compatibility against the enclosing return type (same spirit as the existing err check and Option payload check)
- Rejects `Result[Int, E]` unwrapped inside `Result[Float, E]`
- Added sema regression test

## Test plan
- [x] `cargo test -p skeplib --test frontend_sema_suite result_try_ok`
- [x] Reproduced: mismatched ok types previously passed `skepac check`