### PR TITLE
fix(codegen): support Vec subscript via trapping vec get

### DIFF
--- a/skeplib/src/codegen/llvm/runtime_containers.rs
+++ b/skeplib/src/codegen/llvm/runtime_containers.rs
@@ -323,6 +323,37 @@ pub fn emit_array_get(
             }
         }
     }
+    let container_ty = infer_operand_type(func, array);
+    if matches!(container_ty, IrType::Vec { .. }) {
+        let vec = operand_load(
+            names,
+            array,
+            func,
+            lines,
+            counter,
+            &IrType::Vec {
+                elem: Box::new(elem_ty.clone()),
+            },
+            string_literals,
+        )?;
+        let index = operand_load(
+            names,
+            index,
+            func,
+            lines,
+            counter,
+            &IrType::Int,
+            string_literals,
+        )?;
+        let raw = format!("%v{counter}");
+        *counter += 1;
+        lines.push(format!(
+            "  {raw} = call ptr @skp_rt_vec_get(ptr {vec}, i64 {index})"
+        ));
+        emit_abort_if_error(lines);
+        return emit_unbox_value(names, dst, elem_ty, &raw, lines);
+    }
+
     let array = operand_load(
         names,
         array,

--- a/skeplib/src/ir/interp/exec.rs
+++ b/skeplib/src/ir/interp/exec.rs
@@ -146,7 +146,12 @@ impl<'a> IrInterpreter<'a> {
                     RtValue::Array(items) => {
                         items.get(index).map_err(IrInterpError::from_runtime)?
                     }
-                    _ => return Err(IrInterpError::TypeMismatch("array get on non-array")),
+                    RtValue::Vec(items) => items.get(index).map_err(IrInterpError::from_runtime)?,
+                    _ => {
+                        return Err(IrInterpError::TypeMismatch(
+                            "array/vec get on non-indexable value",
+                        ));
+                    }
                 };
                 frame.temps.insert(*dst, value);
             }

--- a/skeplib/src/ir/lowering/expr.rs
+++ b/skeplib/src/ir/lowering/expr.rs
@@ -198,6 +198,9 @@ impl IrLowerer {
                 let index = self.compile_expr(func, lowering, index)?;
                 let elem_ty = self.array_element_type(func, &array);
                 let dst = self.builder.push_temp(func, elem_ty.clone());
+                // Array and Vec share trapping subscript semantics (element type T).
+                // ArrayGet lowers to skp_rt_array_get / skp_rt_vec_get based on the
+                // operand type — VecGet is reserved for vec.get which returns Option[T].
                 self.builder.push_instr(
                     func,
                     lowering.current_block,

--- a/skeplib/tests/ir/diff/main.rs
+++ b/skeplib/tests/ir/diff/main.rs
@@ -432,6 +432,21 @@ fn main() -> Int {
 }
 
 #[test]
+fn native_and_ir_accept_vec_subscript_indexing() {
+    let source = r#"
+import vec;
+
+fn main() -> Int {
+  let xs: Vec[Int] = vec.new();
+  vec.push(xs, 10);
+  vec.push(xs, 20);
+  return xs[0] + xs[1];
+}
+"#;
+    assert_native_and_ir_accept_same_int_source(source, 30);
+}
+
+#[test]
 fn ir_rejects_runtime_error_sources() {
     assert_ir_rejects_source(
         r#"
@@ -446,6 +461,17 @@ fn main() -> Int {
 fn main() -> Int {
   let arr: [Int; 2] = [1; 2];
   return arr[3];
+}
+"#,
+        RtErrorKind::IndexOutOfBounds,
+    );
+    assert_ir_rejects_source(
+        r#"
+import vec;
+
+fn main() -> Int {
+  let xs: Vec[Int] = vec.new();
+  return xs[0];
 }
 "#,
         RtErrorKind::IndexOutOfBounds,

--- a/skeplib/tests/native/runtime/main.rs
+++ b/skeplib/tests/native/runtime/main.rs
@@ -220,3 +220,19 @@ fn main() -> Int {
     common::assert_native_matches_ir_value(float_src, skepart::value::RtValue::Int(1));
     common::assert_native_matches_ir_value(string_src, skepart::value::RtValue::Int(1));
 }
+
+#[test]
+fn native_and_ir_support_vec_subscript_indexing() {
+    let src = r#"
+import vec;
+
+fn main() -> Int {
+  let xs: Vec[Int] = vec.new();
+  vec.push(xs, 10);
+  vec.push(xs, 20);
+  return xs[0] + xs[1];
+}
+"#;
+
+    common::assert_native_matches_ir_value(src, skepart::value::RtValue::Int(30));
+}


### PR DESCRIPTION
Fixes #87

## Summary
- `xs[i]` on `Vec[T]` type-checked as `T` but always lowered like array get
- Interpreter now accepts `RtValue::Vec` for trapping subscript
- Native codegen calls `skp_rt_vec_get` when the indexed operand is a Vec
- Added IR/native differential coverage for happy path and OOB

## Test plan
- [x] `cargo test -p skeplib --test ir_diff_suite vec_subscript`
- [x] `cargo test -p skeplib --test ir_diff_suite ir_rejects_runtime_error_sources`
- [x] Reproduced: `return xs[0]` on a Vec previously crashed / failed at runtime