### PR TITLE
fix(ir): align BuiltinSig tables with Result/Vec shapes

### DIFF
--- a/skeplib/src/builtins/datetime.rs
+++ b/skeplib/src/builtins/datetime.rs
@@ -1,3 +1,5 @@
+use std::sync::LazyLock;
+
 use crate::types::TypeInfo;
 
 use super::{BuiltinKind, BuiltinSig};
@@ -6,82 +8,91 @@ const DATETIME_NOW_PARAMS: &[TypeInfo] = &[];
 const DATETIME_UNIX_PARAMS: &[TypeInfo] = &[TypeInfo::Int];
 const DATETIME_PARSE_PARAMS: &[TypeInfo] = &[TypeInfo::String];
 
-pub(super) const SIGS: &[BuiltinSig] = &[
-    BuiltinSig {
-        package: "datetime",
-        name: "nowUnix",
-        params: DATETIME_NOW_PARAMS,
-        ret: TypeInfo::Int,
-        kind: BuiltinKind::FixedArity,
-    },
-    BuiltinSig {
-        package: "datetime",
-        name: "nowMillis",
-        params: DATETIME_NOW_PARAMS,
-        ret: TypeInfo::Int,
-        kind: BuiltinKind::FixedArity,
-    },
-    BuiltinSig {
-        package: "datetime",
-        name: "fromUnix",
-        params: DATETIME_UNIX_PARAMS,
-        ret: TypeInfo::String,
-        kind: BuiltinKind::FixedArity,
-    },
-    BuiltinSig {
-        package: "datetime",
-        name: "fromMillis",
-        params: DATETIME_UNIX_PARAMS,
-        ret: TypeInfo::String,
-        kind: BuiltinKind::FixedArity,
-    },
-    BuiltinSig {
-        package: "datetime",
-        name: "parseUnix",
-        params: DATETIME_PARSE_PARAMS,
-        ret: TypeInfo::Int,
-        kind: BuiltinKind::FixedArity,
-    },
-    BuiltinSig {
-        package: "datetime",
-        name: "year",
-        params: DATETIME_UNIX_PARAMS,
-        ret: TypeInfo::Int,
-        kind: BuiltinKind::FixedArity,
-    },
-    BuiltinSig {
-        package: "datetime",
-        name: "month",
-        params: DATETIME_UNIX_PARAMS,
-        ret: TypeInfo::Int,
-        kind: BuiltinKind::FixedArity,
-    },
-    BuiltinSig {
-        package: "datetime",
-        name: "day",
-        params: DATETIME_UNIX_PARAMS,
-        ret: TypeInfo::Int,
-        kind: BuiltinKind::FixedArity,
-    },
-    BuiltinSig {
-        package: "datetime",
-        name: "hour",
-        params: DATETIME_UNIX_PARAMS,
-        ret: TypeInfo::Int,
-        kind: BuiltinKind::FixedArity,
-    },
-    BuiltinSig {
-        package: "datetime",
-        name: "minute",
-        params: DATETIME_UNIX_PARAMS,
-        ret: TypeInfo::Int,
-        kind: BuiltinKind::FixedArity,
-    },
-    BuiltinSig {
-        package: "datetime",
-        name: "second",
-        params: DATETIME_UNIX_PARAMS,
-        ret: TypeInfo::Int,
-        kind: BuiltinKind::FixedArity,
-    },
-];
+fn result_int_string() -> TypeInfo {
+    TypeInfo::Result {
+        ok: Box::new(TypeInfo::Int),
+        err: Box::new(TypeInfo::String),
+    }
+}
+
+pub(super) static SIGS: LazyLock<Vec<BuiltinSig>> = LazyLock::new(|| {
+    vec![
+        BuiltinSig {
+            package: "datetime",
+            name: "nowUnix",
+            params: DATETIME_NOW_PARAMS,
+            ret: TypeInfo::Int,
+            kind: BuiltinKind::FixedArity,
+        },
+        BuiltinSig {
+            package: "datetime",
+            name: "nowMillis",
+            params: DATETIME_NOW_PARAMS,
+            ret: TypeInfo::Int,
+            kind: BuiltinKind::FixedArity,
+        },
+        BuiltinSig {
+            package: "datetime",
+            name: "fromUnix",
+            params: DATETIME_UNIX_PARAMS,
+            ret: TypeInfo::String,
+            kind: BuiltinKind::FixedArity,
+        },
+        BuiltinSig {
+            package: "datetime",
+            name: "fromMillis",
+            params: DATETIME_UNIX_PARAMS,
+            ret: TypeInfo::String,
+            kind: BuiltinKind::FixedArity,
+        },
+        BuiltinSig {
+            package: "datetime",
+            name: "parseUnix",
+            params: DATETIME_PARSE_PARAMS,
+            ret: result_int_string(),
+            kind: BuiltinKind::FixedArity,
+        },
+        BuiltinSig {
+            package: "datetime",
+            name: "year",
+            params: DATETIME_UNIX_PARAMS,
+            ret: TypeInfo::Int,
+            kind: BuiltinKind::FixedArity,
+        },
+        BuiltinSig {
+            package: "datetime",
+            name: "month",
+            params: DATETIME_UNIX_PARAMS,
+            ret: TypeInfo::Int,
+            kind: BuiltinKind::FixedArity,
+        },
+        BuiltinSig {
+            package: "datetime",
+            name: "day",
+            params: DATETIME_UNIX_PARAMS,
+            ret: TypeInfo::Int,
+            kind: BuiltinKind::FixedArity,
+        },
+        BuiltinSig {
+            package: "datetime",
+            name: "hour",
+            params: DATETIME_UNIX_PARAMS,
+            ret: TypeInfo::Int,
+            kind: BuiltinKind::FixedArity,
+        },
+        BuiltinSig {
+            package: "datetime",
+            name: "minute",
+            params: DATETIME_UNIX_PARAMS,
+            ret: TypeInfo::Int,
+            kind: BuiltinKind::FixedArity,
+        },
+        BuiltinSig {
+            package: "datetime",
+            name: "second",
+            params: DATETIME_UNIX_PARAMS,
+            ret: TypeInfo::Int,
+            kind: BuiltinKind::FixedArity,
+        },
+    ]
+});

--- a/skeplib/src/builtins/fs.rs
+++ b/skeplib/src/builtins/fs.rs
@@ -1,3 +1,5 @@
+use std::sync::LazyLock;
+
 use crate::types::TypeInfo;
 
 use super::{BuiltinKind, BuiltinSig};
@@ -5,61 +7,84 @@ use super::{BuiltinKind, BuiltinSig};
 const STRING1: &[TypeInfo] = &[TypeInfo::String];
 const STRING2: &[TypeInfo] = &[TypeInfo::String, TypeInfo::String];
 
-pub(super) const SIGS: &[BuiltinSig] = &[
-    BuiltinSig {
-        package: "fs",
-        name: "exists",
-        params: STRING1,
-        ret: TypeInfo::Unknown,
-        kind: BuiltinKind::FixedArity,
-    },
-    BuiltinSig {
-        package: "fs",
-        name: "readText",
-        params: STRING1,
-        ret: TypeInfo::String,
-        kind: BuiltinKind::FixedArity,
-    },
-    BuiltinSig {
-        package: "fs",
-        name: "writeText",
-        params: STRING2,
-        ret: TypeInfo::Void,
-        kind: BuiltinKind::FixedArity,
-    },
-    BuiltinSig {
-        package: "fs",
-        name: "appendText",
-        params: STRING2,
-        ret: TypeInfo::Void,
-        kind: BuiltinKind::FixedArity,
-    },
-    BuiltinSig {
-        package: "fs",
-        name: "mkdirAll",
-        params: STRING1,
-        ret: TypeInfo::Void,
-        kind: BuiltinKind::FixedArity,
-    },
-    BuiltinSig {
-        package: "fs",
-        name: "removeFile",
-        params: STRING1,
-        ret: TypeInfo::Void,
-        kind: BuiltinKind::FixedArity,
-    },
-    BuiltinSig {
-        package: "fs",
-        name: "removeDirAll",
-        params: STRING1,
-        ret: TypeInfo::Void,
-        kind: BuiltinKind::FixedArity,
-    },
-    BuiltinSig {
-        package: "fs",
-        name: "join",
-        params: STRING2,
-        ret: TypeInfo::String,
-        kind: BuiltinKind::FixedArity,
-    },
-];
+fn result_bool_string() -> TypeInfo {
+    TypeInfo::Result {
+        ok: Box::new(TypeInfo::Bool),
+        err: Box::new(TypeInfo::String),
+    }
+}
+
+fn result_string_string() -> TypeInfo {
+    TypeInfo::Result {
+        ok: Box::new(TypeInfo::String),
+        err: Box::new(TypeInfo::String),
+    }
+}
+
+fn result_void_string() -> TypeInfo {
+    TypeInfo::Result {
+        ok: Box::new(TypeInfo::Void),
+        err: Box::new(TypeInfo::String),
+    }
+}
+
+pub(super) static SIGS: LazyLock<Vec<BuiltinSig>> = LazyLock::new(|| {
+    vec![
+        BuiltinSig {
+            package: "fs",
+            name: "exists",
+            params: STRING1,
+            ret: result_bool_string(),
+            kind: BuiltinKind::FixedArity,
+        },
+        BuiltinSig {
+            package: "fs",
+            name: "readText",
+            params: STRING1,
+            ret: result_string_string(),
+            kind: BuiltinKind::FixedArity,
+        },
+        BuiltinSig {
+            package: "fs",
+            name: "writeText",
+            params: STRING2,
+            ret: result_void_string(),
+            kind: BuiltinKind::FixedArity,
+        },
+        BuiltinSig {
+            package: "fs",
+            name: "appendText",
+            params: STRING2,
+            ret: result_void_string(),
+            kind: BuiltinKind::FixedArity,
+        },
+        BuiltinSig {
+            package: "fs",
+            name: "mkdirAll",
+            params: STRING1,
+            ret: result_void_string(),
+            kind: BuiltinKind::FixedArity,
+        },
+        BuiltinSig {
+            package: "fs",
+            name: "removeFile",
+            params: STRING1,
+            ret: result_void_string(),
+            kind: BuiltinKind::FixedArity,
+        },
+        BuiltinSig {
+            package: "fs",
+            name: "removeDirAll",
+            params: STRING1,
+            ret: result_void_string(),
+            kind: BuiltinKind::FixedArity,
+        },
+        BuiltinSig {
+            package: "fs",
+            name: "join",
+            params: STRING2,
+            ret: TypeInfo::String,
+            kind: BuiltinKind::FixedArity,
+        },
+    ]
+});

--- a/skeplib/src/builtins/os.rs
+++ b/skeplib/src/builtins/os.rs
@@ -1,3 +1,5 @@
+use std::sync::LazyLock;
+
 use crate::types::TypeInfo;
 
 use super::{BuiltinKind, BuiltinSig};
@@ -7,82 +9,108 @@ const INT_PARAM: &[TypeInfo] = &[TypeInfo::Int];
 const STRING_PARAM: &[TypeInfo] = &[TypeInfo::String];
 const STRING2_PARAMS: &[TypeInfo] = &[TypeInfo::String, TypeInfo::String];
 
-pub(super) const SIGS: &[BuiltinSig] = &[
-    BuiltinSig {
-        package: "os",
-        name: "platform",
-        params: NO_PARAMS,
-        ret: TypeInfo::String,
-        kind: BuiltinKind::FixedArity,
-    },
-    BuiltinSig {
-        package: "os",
-        name: "arch",
-        params: NO_PARAMS,
-        ret: TypeInfo::String,
-        kind: BuiltinKind::FixedArity,
-    },
-    BuiltinSig {
-        package: "os",
-        name: "arg",
-        params: INT_PARAM,
-        ret: TypeInfo::Unknown,
-        kind: BuiltinKind::FixedArity,
-    },
-    BuiltinSig {
-        package: "os",
-        name: "envHas",
-        params: STRING_PARAM,
-        ret: TypeInfo::Bool,
-        kind: BuiltinKind::FixedArity,
-    },
-    BuiltinSig {
-        package: "os",
-        name: "envGet",
-        params: STRING_PARAM,
-        ret: TypeInfo::Unknown,
-        kind: BuiltinKind::FixedArity,
-    },
-    BuiltinSig {
-        package: "os",
-        name: "envSet",
-        params: STRING2_PARAMS,
-        ret: TypeInfo::Void,
-        kind: BuiltinKind::FixedArity,
-    },
-    BuiltinSig {
-        package: "os",
-        name: "envRemove",
-        params: STRING_PARAM,
-        ret: TypeInfo::Void,
-        kind: BuiltinKind::FixedArity,
-    },
-    BuiltinSig {
-        package: "os",
-        name: "sleep",
-        params: INT_PARAM,
-        ret: TypeInfo::Void,
-        kind: BuiltinKind::FixedArity,
-    },
-    BuiltinSig {
-        package: "os",
-        name: "exit",
-        params: INT_PARAM,
-        ret: TypeInfo::Void,
-        kind: BuiltinKind::FixedArity,
-    },
-    BuiltinSig {
-        package: "os",
-        name: "exec",
-        params: STRING2_PARAMS,
-        ret: TypeInfo::Unknown,
-        kind: BuiltinKind::FixedArity,
-    },
-    BuiltinSig {
-        package: "os",
-        name: "execOut",
-        params: STRING2_PARAMS,
-        ret: TypeInfo::Unknown,
-        kind: BuiltinKind::FixedArity,
-    },
-];
+fn string_and_vec_string_params() -> &'static [TypeInfo] {
+    Box::leak(Box::new([
+        TypeInfo::String,
+        TypeInfo::Vec {
+            elem: Box::new(TypeInfo::String),
+        },
+    ]))
+}
+
+fn result_int_string() -> TypeInfo {
+    TypeInfo::Result {
+        ok: Box::new(TypeInfo::Int),
+        err: Box::new(TypeInfo::String),
+    }
+}
+
+fn result_string_string() -> TypeInfo {
+    TypeInfo::Result {
+        ok: Box::new(TypeInfo::String),
+        err: Box::new(TypeInfo::String),
+    }
+}
+
+pub(super) static SIGS: LazyLock<Vec<BuiltinSig>> = LazyLock::new(|| {
+    let string_and_vec_string = string_and_vec_string_params();
+    vec![
+        BuiltinSig {
+            package: "os",
+            name: "platform",
+            params: NO_PARAMS,
+            ret: TypeInfo::String,
+            kind: BuiltinKind::FixedArity,
+        },
+        BuiltinSig {
+            package: "os",
+            name: "arch",
+            params: NO_PARAMS,
+            ret: TypeInfo::String,
+            kind: BuiltinKind::FixedArity,
+        },
+        BuiltinSig {
+            package: "os",
+            name: "arg",
+            params: INT_PARAM,
+            ret: TypeInfo::Unknown,
+            kind: BuiltinKind::FixedArity,
+        },
+        BuiltinSig {
+            package: "os",
+            name: "envHas",
+            params: STRING_PARAM,
+            ret: TypeInfo::Bool,
+            kind: BuiltinKind::FixedArity,
+        },
+        BuiltinSig {
+            package: "os",
+            name: "envGet",
+            params: STRING_PARAM,
+            ret: TypeInfo::Unknown,
+            kind: BuiltinKind::FixedArity,
+        },
+        BuiltinSig {
+            package: "os",
+            name: "envSet",
+            params: STRING2_PARAMS,
+            ret: TypeInfo::Void,
+            kind: BuiltinKind::FixedArity,
+        },
+        BuiltinSig {
+            package: "os",
+            name: "envRemove",
+            params: STRING_PARAM,
+            ret: TypeInfo::Void,
+            kind: BuiltinKind::FixedArity,
+        },
+        BuiltinSig {
+            package: "os",
+            name: "sleep",
+            params: INT_PARAM,
+            ret: TypeInfo::Void,
+            kind: BuiltinKind::FixedArity,
+        },
+        BuiltinSig {
+            package: "os",
+            name: "exit",
+            params: INT_PARAM,
+            ret: TypeInfo::Void,
+            kind: BuiltinKind::FixedArity,
+        },
+        BuiltinSig {
+            package: "os",
+            name: "exec",
+            params: string_and_vec_string,
+            ret: result_int_string(),
+            kind: BuiltinKind::FixedArity,
+        },
+        BuiltinSig {
+            package: "os",
+            name: "execOut",
+            params: string_and_vec_string,
+            ret: result_string_string(),
+            kind: BuiltinKind::FixedArity,
+        },
+    ]
+});

--- a/skeplib/tests/ir_builtin_sig_result.rs
+++ b/skeplib/tests/ir_builtin_sig_result.rs
@@ -1,0 +1,53 @@
+use skeplib::ir::{self, IrVerifier};
+
+#[test]
+fn ir_verify_accepts_fs_read_text_result_builtin() {
+    let source = r#"
+import fs;
+
+fn main() -> Int {
+  let missing = fs.readText("definitely-missing-skepa-file.txt");
+  let kept = missing;
+  return 0;
+}
+"#;
+
+    let program = ir::lowering::compile_source(source).expect("IR lowering should succeed");
+    IrVerifier::verify_program(&program)
+        .expect("IR verify should accept fs.readText Result return");
+}
+
+#[test]
+fn ir_verify_accepts_datetime_parse_unix_result_builtin() {
+    let source = r#"
+import datetime;
+
+fn main() -> Int {
+  let parsed = datetime.parseUnix("1970-01-01T00:00:00Z");
+  let kept = parsed;
+  return 0;
+}
+"#;
+
+    let program = ir::lowering::compile_source(source).expect("IR lowering should succeed");
+    IrVerifier::verify_program(&program)
+        .expect("IR verify should accept datetime.parseUnix Result return");
+}
+
+#[test]
+fn ir_verify_accepts_os_exec_vec_argv() {
+    let source = r#"
+import os;
+import vec;
+
+fn main() -> Int {
+  let args: Vec[String] = vec.new();
+  let status = os.exec("true", args);
+  let kept = status;
+  return 0;
+}
+"#;
+
+    let program = ir::lowering::compile_source(source).expect("IR lowering should succeed");
+    IrVerifier::verify_program(&program).expect("IR verify should accept os.exec Vec[String] argv");
+}


### PR DESCRIPTION
Fixes #88

## Summary
- Updated `fs`, `datetime`, and `os` BuiltinSig metadata to match sema/docs:
  - `fs.readText` / friends and `datetime.parseUnix` return `Result[..., String]`
  - `os.exec` / `os.execOut` take `Vec[String]` argv and return `Result`
- IR verify no longer rejects programs that already passed `skepac check`
- Added verify regression tests for the affected builtins

## Test plan
- [x] `cargo test -p skeplib --test ir_builtin_sig_result`
- [x] `cargo clippy -p skeplib --all-targets --all-features -- -D warnings`
- [x] Reproduced: `fs.readText(...)` previously failed IR verify after successful check