### PR TITLE
fix(ir): lower Ident assigns to registered globals

### DIFF
--- a/skepac/tests/check_cli.rs
+++ b/skepac/tests/check_cli.rs
@@ -2859,6 +2859,37 @@ fn main() -> Int {
 #[test]
 fn run_reports_ir_lowering_failure_as_codegen() {
     let tmp = make_temp_dir("skepac_run_lowering_exit_codegen");
+    // Assigning to a function binding still passes check today but is not a
+    // lowerable Ident store target (unlike module globals, which now lower).
+    let source = write_temp_file(
+        &tmp,
+        "main.sk",
+        r#"
+fn bump() -> Int { return 1; }
+fn main() -> Int {
+  bump = bump;
+  return 0;
+}
+"#,
+    );
+
+    let output = Command::new(skepac_bin())
+        .arg("run")
+        .arg(&source)
+        .output()
+        .expect("run skepac run");
+
+    assert_cli_failure_class(&output, CliFailureClass::Codegen);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("assignment to unknown local `bump`"),
+        "stderr was: {stderr}"
+    );
+}
+
+#[test]
+fn run_executes_global_ident_assignment_end_to_end() {
+    let tmp = make_temp_dir("skepac_run_global_ident_assign");
     let source = write_temp_file(
         &tmp,
         "main.sk",
@@ -2877,12 +2908,7 @@ fn main() -> Int {
         .output()
         .expect("run skepac run");
 
-    assert_cli_failure_class(&output, CliFailureClass::Codegen);
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        stderr.contains("assignment to unknown local `counter`"),
-        "stderr was: {stderr}"
-    );
+    assert_eq!(output.status.code(), Some(1), "{output:?}");
 }
 
 #[test]

--- a/skeplib/src/ir/lowering/stmt.rs
+++ b/skeplib/src/ir/lowering/stmt.rs
@@ -74,26 +74,38 @@ impl IrLowerer {
                     Some(value) => value,
                     None => return false,
                 };
-                let Some(&local) = lowering.locals.get(name) else {
-                    self.unsupported(format!("assignment to unknown local `{name}`"));
-                    return false;
-                };
-                let ty = func
-                    .locals
-                    .iter()
-                    .find(|entry| entry.id == local)
-                    .map(|entry| entry.ty.clone())
-                    .unwrap_or(IrType::Unknown);
-                self.builder.push_instr(
-                    func,
-                    lowering.current_block,
-                    Instr::StoreLocal {
-                        local,
-                        ty,
-                        value: rhs,
-                    },
-                );
-                true
+                if let Some(&local) = lowering.locals.get(name) {
+                    let ty = func
+                        .locals
+                        .iter()
+                        .find(|entry| entry.id == local)
+                        .map(|entry| entry.ty.clone())
+                        .unwrap_or(IrType::Unknown);
+                    self.builder.push_instr(
+                        func,
+                        lowering.current_block,
+                        Instr::StoreLocal {
+                            local,
+                            ty,
+                            value: rhs,
+                        },
+                    );
+                    return true;
+                }
+                if let Some((global, ty)) = self.resolve_assign_global(name) {
+                    self.builder.push_instr(
+                        func,
+                        lowering.current_block,
+                        Instr::StoreGlobal {
+                            global,
+                            ty,
+                            value: rhs,
+                        },
+                    );
+                    return true;
+                }
+                self.unsupported(format!("assignment to unknown local `{name}`"));
+                false
             }
             Stmt::Assign {
                 target: AssignTarget::Index { base, index },
@@ -640,6 +652,15 @@ impl IrLowerer {
                 .map(|candidate| &candidate.terminator),
             Some(Terminator::Unreachable)
         )
+    }
+
+    fn resolve_assign_global(&self, name: &str) -> Option<(crate::ir::GlobalId, IrType)> {
+        self.imported_global_names
+            .get(name)
+            .and_then(|qualified| self.globals.get(qualified))
+            .or_else(|| self.globals.get(name))
+            .or_else(|| self.globals.get(&self.qualify_name(name)))
+            .cloned()
     }
 
     fn try_compile_typed_empty_array_let(

--- a/skeplib/tests/ir/diff/main.rs
+++ b/skeplib/tests/ir/diff/main.rs
@@ -488,3 +488,18 @@ fn main() -> String {
         RtErrorKind::InvalidArgument,
     );
 }
+
+#[test]
+fn native_and_ir_accept_same_global_ident_assignment() {
+    let source = r#"
+let counter: Int = 1;
+fn bump() -> Int {
+  counter = counter + 1;
+  return counter;
+}
+fn main() -> Int {
+  return bump();
+}
+"#;
+    assert_native_and_ir_accept_same_int_source(source, 2);
+}

--- a/skeplib/tests/ir/diff/main.rs
+++ b/skeplib/tests/ir/diff/main.rs
@@ -502,6 +502,9 @@ fn main() -> Int {
 }
 "#;
     assert_native_and_ir_accept_same_int_source(source, 2);
+}
+
+#[test]
 fn native_and_ir_accept_same_match_or_pattern() {
     let source = r#"
 fn main() -> Int {


### PR DESCRIPTION
## Summary
Fixes #55: Ident assignment now emits `StoreGlobal` when the name resolves to a registered or imported module global, matching sema which already accepts global mutation.

## Area
- ir
- tests

## Why
`skepac check` accepted `counter = counter + 1` on a module global, but IR lowering only looked up locals and failed with `assignment to unknown local`.

## What Changed
- resolve Ident assigns through the same global/import lookup used for global reads
- emit `StoreGlobal` for matched globals; keep `StoreLocal` for locals
- add IR/native differential regression coverage

## Validation
- [x] `cargo fmt --all`
- [x] focused tests for touched area
- [x] `cargo clippy -p skeplib --all-targets --all-features -- -D warnings`

Commands run:
```bash
cargo fmt --all
cargo clippy -p skeplib --all-targets --all-features -- -D warnings
cargo test -p skeplib --test ir_diff_suite native_and_ir_accept_same_global_ident_assignment
```

## Notes for Review
Reads of globals already worked; only Ident mutation was missing.

Made with [Cursor](https://cursor.com)