### PR TITLE
fix(codegen): emit LLVM and/or for Instr::Logic

### DIFF
--- a/skeplib/src/codegen/llvm/context.rs
+++ b/skeplib/src/codegen/llvm/context.rs
@@ -279,12 +279,10 @@ impl<'a> LlvmEmitter<'a> {
             | Instr::VecDelete { .. }
             | Instr::MakeStruct { .. }
             | Instr::StructGet { .. }
-            | Instr::StructSet { .. } => {
+            | Instr::StructSet { .. }
+            | Instr::Logic { .. } => {
                 unreachable!("scalar/core/runtime instructions handled earlier")
             }
-            Instr::Logic { .. } => Err(CodegenError::Unsupported(
-                "Logic instructions should be lowered to control flow before LLVM emission",
-            )),
         }
     }
 }

--- a/skeplib/src/codegen/llvm/instr_core.rs
+++ b/skeplib/src/codegen/llvm/instr_core.rs
@@ -3,7 +3,8 @@ use crate::codegen::llvm::calls::{self, DirectCall};
 use crate::codegen::llvm::types::llvm_ty;
 use crate::codegen::llvm::value::{ValueNames, operand_load};
 use crate::ir::{
-    Instr, IrFunction, IrProgram, LoweredIrFunction, NativeArrayPlan, NativeStructPlan,
+    Instr, IrFunction, IrProgram, IrType, LogicOp, LoweredIrFunction, NativeArrayPlan,
+    NativeStructPlan,
 };
 use std::collections::HashMap;
 
@@ -179,6 +180,38 @@ pub fn emit_core_instr(
                 counter,
                 string_literals,
             )?;
+            Ok(true)
+        }
+        Instr::Logic {
+            dst,
+            op,
+            left,
+            right,
+        } => {
+            let dest = names.temp(*dst)?;
+            let left = operand_load(
+                names,
+                left,
+                func,
+                lines,
+                counter,
+                &IrType::Bool,
+                string_literals,
+            )?;
+            let right = operand_load(
+                names,
+                right,
+                func,
+                lines,
+                counter,
+                &IrType::Bool,
+                string_literals,
+            )?;
+            let opcode = match op {
+                LogicOp::And => "and",
+                LogicOp::Or => "or",
+            };
+            lines.push(format!("  {dest} = {opcode} i1 {left}, {right}"));
             Ok(true)
         }
         _ => Ok(false),

--- a/skeplib/tests/ir/diff/main.rs
+++ b/skeplib/tests/ir/diff/main.rs
@@ -488,3 +488,17 @@ fn main() -> String {
         RtErrorKind::InvalidArgument,
     );
 }
+
+#[test]
+fn native_and_ir_accept_same_match_or_pattern() {
+    let source = r#"
+fn main() -> Int {
+  let x: Int = 1;
+  match (x) {
+    1 | 2 => { return 42; }
+    _ => { return 0; }
+  }
+}
+"#;
+    assert_native_and_ir_accept_same_int_source(source, 42);
+}


### PR DESCRIPTION
## Summary
Fixes #54: match OR-patterns already lower to `Instr::Logic`, but LLVM emission rejected Logic. Emit non-short-circuiting `and`/`or` on `i1` so documented OR matches run natively.

## Area
- codegen
- tests

## Why
`skepac check` accepted `1 | 2` match arms, but `run` / `build-native` failed with “Logic instructions should be lowered to control flow before LLVM emission”.

## What Changed
- emit `Instr::Logic` as `and i1` / `or i1` in core LLVM lowering
- remove the unsupported Logic codegen error path
- add IR/native differential coverage for match OR-patterns

## Validation
- [x] `cargo fmt --all`
- [x] focused tests for touched area
- [x] `cargo clippy -p skeplib --all-targets --all-features -- -D warnings`

Commands run:
```bash
cargo fmt --all
cargo clippy -p skeplib --all-targets --all-features -- -D warnings
cargo test -p skeplib --test ir_diff_suite native_and_ir_accept_same_match_or_pattern
```

## Notes for Review
Expression `||` / `&&` remain CFG short-circuit lowered. Match OR still evaluates alternatives eagerly via Logic, which is intentional for pure pattern conditions.

Made with [Cursor](https://cursor.com)