### PR TITLE
fix(parser): publish operator export after full header scan

### DIFF
--- a/skeplib/src/parser/mod.rs
+++ b/skeplib/src/parser/mod.rs
@@ -94,6 +94,9 @@ impl Parser {
         let mut out = SourceHeaderInfo::default();
         let mut idx = 0usize;
         let mut brace_depth = 0usize;
+        // Collect export aliases first; resolve operator precedences after the full
+        // scan so `export { op };` before `opr op ...` still publishes precedence.
+        let mut pending_exported_names: Vec<(String, String)> = Vec::new();
 
         while idx < tokens.len() {
             match tokens[idx].kind {
@@ -281,12 +284,7 @@ impl Parser {
                             } else {
                                 local_name.clone()
                             };
-                        if let Some(precedence) =
-                            out.local_operator_precedences.get(&local_name).copied()
-                        {
-                            out.local_exported_operator_precedences
-                                .insert(export_name, precedence);
-                        }
+                        pending_exported_names.push((local_name, export_name));
                         if !matches!(tokens.get(scan).map(|t| t.kind), Some(TokenKind::Comma)) {
                             continue;
                         }
@@ -358,6 +356,13 @@ impl Parser {
                 _ => {
                     idx += 1;
                 }
+            }
+        }
+
+        for (local_name, export_name) in pending_exported_names {
+            if let Some(precedence) = out.local_operator_precedences.get(&local_name).copied() {
+                out.local_exported_operator_precedences
+                    .insert(export_name, precedence);
             }
         }
 

--- a/skeplib/tests/ir_project_imported_operator.rs
+++ b/skeplib/tests/ir_project_imported_operator.rs
@@ -62,3 +62,30 @@ fn main() -> Int {
         "lowering should not invent a local operator target for the imported name"
     );
 }
+
+#[test]
+fn project_lowers_operator_when_export_precedes_opr() {
+    let project = common::TempProject::new("project_export_before_opr");
+    project.file(
+        "ops.sk",
+        r#"
+export { add };
+opr add(a: Int, b: Int) -> Int precedence 5 { return a + b; }
+"#,
+    );
+    let entry = project.file(
+        "main.sk",
+        r#"
+from ops import add;
+fn main() -> Int {
+  return 2 `add` 3;
+}
+"#,
+    );
+
+    let program = lowering::compile_project_entry(&entry).expect("project lowering should succeed");
+    let value = IrInterpreter::new(&program)
+        .run_main()
+        .expect("IR interpreter should run");
+    assert_eq!(value, RtValue::Int(5));
+}

--- a/skeplib/tests/resolver_import_audit.rs
+++ b/skeplib/tests/resolver_import_audit.rs
@@ -74,6 +74,27 @@ fn main() -> Int { return 1 `xoxo` 2; }
 }
 
 #[test]
+fn accepts_operator_export_declared_before_opr() {
+    let project = common::TempProject::new("export_before_opr_precedence");
+    project.file(
+        "ops.sk",
+        r#"
+export { add };
+opr add(a: Int, b: Int) -> Int precedence 5 { return a + b; }
+"#,
+    );
+    let entry = project.file(
+        "main.sk",
+        r#"
+from ops import add;
+fn main() -> Int { return 2 `add` 3; }
+"#,
+    );
+
+    resolve_project(&entry).expect("export before opr should still export operator precedence");
+}
+
+#[test]
 fn rejects_duplicate_imported_operator_precedence_before_parse() {
     let project = common::TempProject::new("duplicate_imported_operator_precedence");
     project.file(


### PR DESCRIPTION
## Summary
Fixes #62: `export { add };` before `opr add ... precedence N` now still publishes operator precedence to importers, so `` `add` `` infix imports work regardless of declaration order.

## Area
- parser
- resolver
- tests

## Why
Header scanning only recorded exported operator precedence when `opr` had already been seen. Export-first modules failed importer infix use even though the symbol export itself existed.

## What Changed
- collect exported names during the header scan
- resolve local operator precedences onto those exports after the full scan
- add resolver and project IR regression coverage for export-before-opr

## Validation
- [x] `cargo fmt --all`
- [x] focused tests for touched area
- [x] `cargo clippy -p skeplib --all-targets --all-features -- -D warnings`

Commands run:
```bash
cargo fmt --all
cargo clippy -p skeplib --all-targets --all-features -- -D warnings
cargo test -p skeplib --test resolver_import_audit accepts_operator_export_declared_before_opr
cargo test -p skeplib --test ir_project_imported_operator project_lowers_operator_when_export_precedes_opr
```

## Notes for Review
Call-form imports were already fine; this restores infix precedence visibility for export-before-opr modules.

Made with [Cursor](https://cursor.com)