### PR TITLE
fix(cli): optimize IR before multi-module native partition

### DIFF
--- a/skepac/src/commands.rs
+++ b/skepac/src/commands.rs
@@ -223,7 +223,7 @@ fn build_native_multi_module(
     mut timings: BuildTimings,
 ) -> Result<i32, String> {
     let lower_start = Instant::now();
-    let program = match compile_project_graph_unoptimized_or_report(graph, input) {
+    let program = match compile_project_graph_or_report(graph, input) {
         Ok(program) => program,
         Err(code) => return Ok(code),
     };
@@ -435,19 +435,6 @@ fn resolve_project_or_report(input: &str) -> Result<ModuleGraph, i32> {
 
 fn compile_project_graph_or_report(graph: &ModuleGraph, input: &str) -> Result<ir::IrProgram, i32> {
     match ir::lowering::compile_project_graph_after_frontend(graph, Path::new(input)) {
-        Ok(program) => Ok(program),
-        Err(message) => {
-            eprintln!("[E-CODEGEN][codegen] {message}");
-            Err(EXIT_CODEGEN as i32)
-        }
-    }
-}
-
-fn compile_project_graph_unoptimized_or_report(
-    graph: &ModuleGraph,
-    input: &str,
-) -> Result<ir::IrProgram, i32> {
-    match ir::lowering::compile_project_graph_after_frontend_unoptimized(graph, Path::new(input)) {
         Ok(program) => Ok(program),
         Err(message) => {
             eprintln!("[E-CODEGEN][codegen] {message}");

--- a/skepac/src/commands.rs
+++ b/skepac/src/commands.rs
@@ -223,10 +223,13 @@ fn build_native_multi_module(
     mut timings: BuildTimings,
 ) -> Result<i32, String> {
     let lower_start = Instant::now();
-    let program = match compile_project_graph_or_report(graph, input) {
+    let mut program = match compile_project_graph_unoptimized_or_report(graph, input) {
         Ok(program) => program,
         Err(code) => return Ok(code),
     };
+    // Apply the shared opt pipeline, but skip inlining so module partitions stay
+    // independently cacheable (cross-module inlining couples fingerprints).
+    ir::opt::optimize_program_for_partitions(&mut program);
     timings.record("ir_lowering", lower_start.elapsed());
 
     let partition_start = Instant::now();
@@ -435,6 +438,19 @@ fn resolve_project_or_report(input: &str) -> Result<ModuleGraph, i32> {
 
 fn compile_project_graph_or_report(graph: &ModuleGraph, input: &str) -> Result<ir::IrProgram, i32> {
     match ir::lowering::compile_project_graph_after_frontend(graph, Path::new(input)) {
+        Ok(program) => Ok(program),
+        Err(message) => {
+            eprintln!("[E-CODEGEN][codegen] {message}");
+            Err(EXIT_CODEGEN as i32)
+        }
+    }
+}
+
+fn compile_project_graph_unoptimized_or_report(
+    graph: &ModuleGraph,
+    input: &str,
+) -> Result<ir::IrProgram, i32> {
+    match ir::lowering::compile_project_graph_after_frontend_unoptimized(graph, Path::new(input)) {
         Ok(program) => Ok(program),
         Err(message) => {
             eprintln!("[E-CODEGEN][codegen] {message}");

--- a/skepac/tests/check_cli.rs
+++ b/skepac/tests/check_cli.rs
@@ -2747,6 +2747,76 @@ export { add };
 }
 
 #[test]
+fn build_native_multi_module_applies_ir_optimization_and_matches_run() {
+    let tmp = make_temp_dir("skepac_build_native_multi_optimize");
+    fs::create_dir_all(tmp.join("utils")).expect("create utils");
+    let main = tmp.join("main.sk");
+    let util = tmp.join("utils").join("math.sk");
+    let out = tmp.join(format!("main.{}", exe_ext()));
+
+    fs::write(
+        &util,
+        r#"
+export { answer };
+fn answer() -> Int { return 20 + 22; }
+"#,
+    )
+    .expect("write util");
+    fs::write(
+        &main,
+        r#"
+from utils.math import answer;
+fn main() -> Int { return answer(); }
+"#,
+    )
+    .expect("write main");
+
+    let run = Command::new(skepac_bin())
+        .arg("run")
+        .arg(&main)
+        .output()
+        .expect("run skepac run");
+    assert_eq!(run.status.code(), Some(42), "{run:?}");
+
+    let build = Command::new(skepac_bin())
+        .env("SKEPAC_DEBUG_PARTITION_LLVM", "1")
+        .arg("build-native")
+        .arg(&main)
+        .arg(&out)
+        .output()
+        .expect("run build-native");
+    assert!(build.status.success(), "{build:?}");
+
+    let native = Command::new(&out)
+        .output()
+        .expect("execute partitioned native binary");
+    assert_eq!(native.status.code(), Some(42), "{native:?}");
+
+    let partition_llvm_dir = tmp.join(".skepac-cache").join("partition-llvm");
+    assert!(
+        partition_llvm_dir.is_dir(),
+        "expected partition LLVM dump at {}",
+        partition_llvm_dir.display()
+    );
+    let mut saw_folded_const = false;
+    for entry in fs::read_dir(&partition_llvm_dir).expect("read partition llvm dir") {
+        let path = entry.expect("dir entry").path();
+        if path.extension().and_then(|ext| ext.to_str()) != Some("ll") {
+            continue;
+        }
+        let ir = fs::read_to_string(&path).expect("read partition llvm");
+        if ir.contains("ret i64 42") {
+            saw_folded_const = true;
+            break;
+        }
+    }
+    assert!(
+        saw_folded_const,
+        "multi-module build-native should run the IR optimization pipeline before partitioning"
+    );
+}
+
+#[test]
 fn build_native_partitioned_semantic_dependency_edit_reuses_unchanged_partition_objects() {
     let tmp = make_temp_dir("skepac_build_native_partitioned_dependency_edit");
     fs::create_dir_all(tmp.join("utils")).expect("create utils");

--- a/skeplib/src/ir/opt/mod.rs
+++ b/skeplib/src/ir/opt/mod.rs
@@ -11,14 +11,34 @@ mod strength_reduce;
 
 use crate::ir::IrProgram;
 
+#[derive(Debug, Clone, Copy)]
+struct OptimizeOptions {
+    inline: bool,
+}
+
 pub fn optimize_program(program: &mut IrProgram) {
+    optimize_program_with(program, OptimizeOptions { inline: true });
+}
+
+/// Optimize IR while keeping call boundaries intact.
+///
+/// Partitioned multi-module native builds cache objects per module. Cross-module
+/// inlining embeds callee bodies into callers and couples partition fingerprints,
+/// so incremental rebuilds would invalidate unrelated modules.
+pub fn optimize_program_for_partitions(program: &mut IrProgram) {
+    optimize_program_with(program, OptimizeOptions { inline: false });
+}
+
+fn optimize_program_with(program: &mut IrProgram, options: OptimizeOptions) {
     loop {
         let mut changed = false;
         changed |= const_fold::run(program);
         changed |= copy_prop::run(program);
         changed |= dce::run(program);
         changed |= cfg_simplify::run(program);
-        changed |= inlining::run(program);
+        if options.inline {
+            changed |= inlining::run(program);
+        }
         changed |= dead_store::run(program);
         changed |= loop_simplify::run(program);
         changed |= licm::run(program);


### PR DESCRIPTION
## Summary
Fixes #60: multi-module `skepac build-native` now runs the IR optimization pipeline before partitioning (const-fold, DCE, etc.), matching `run` more closely instead of lowering fully unoptimized IR.

## Area
- cli
- ir
- tests

## Why
Projects with more than one module skipped `optimize_program`, so behavior and performance diverged from `run` / single-file builds.

## What Changed
- apply `optimize_program_for_partitions` after unoptimized lowering in `build_native_multi_module`
- skip inlining in that path so module partitions stay independently cacheable
- add a CLI regression that checks run/native agreement and that partitioned LLVM contains a const-folded `ret i64 42`

## Validation
- [x] `cargo fmt --all`
- [x] focused tests for touched area
- [x] `cargo clippy -p skepac -p skeplib --all-targets --all-features -- -D warnings`

Commands run:
```bash
cargo fmt --all
cargo clippy -p skepac -p skeplib --all-targets --all-features -- -D warnings
cargo test -p skepac --test check_cli build_native_
```

## Notes for Review
Inlining is intentionally omitted for partitioned builds: embedding callees across modules would invalidate unrelated partition object caches. `skepac run` still uses the full optimize pipeline including inlining.